### PR TITLE
Fix: Clean up AndroidManifest.xml in common-database

### DIFF
--- a/common/database/src/main/AndroidManifest.xml
+++ b/common/database/src/main/AndroidManifest.xml
@@ -1,4 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
-    /
-</manifest>
+<manifest />


### PR DESCRIPTION
Remove unnecessary characters from the manifest file to make it a valid empty manifest.