### PR TITLE
feat: use collectAsStateWithLifecycle instead of collectAsState in Compose

### DIFF
--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
@@ -135,9 +135,7 @@ private fun RewardListScreen(
     val ticket by viewModel.rewardPoint.observeAsState()
     val rewards by viewModel.rewardList.observeAsState()
     val result by viewModel.result.observeAsState()
-    // TODO can use collectAsStateWithLifecycle() if library update
-    // https://qiita.com/dosukoi_android/items/e8bbaa662c52b8e1cc20
-    val obtainedReward by viewModel.obtainedReward.collectAsState()
+    val obtainedReward by viewModel.obtainedReward.collectAsStateWithLifecycle()
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +26,7 @@ fun SettingScreen(
     onTodoistAuthStartClicked: () -> Unit,
     viewModel: SettingViewModel = hiltViewModel(),
 ) {
-    val todoistExtensionEnabled = viewModel.hasAccessToken.collectAsState()
+    val todoistExtensionEnabled = viewModel.hasAccessToken.collectAsStateWithLifecycle()
     val onTodoistAuthClearClicked: () -> Unit = {
         viewModel.clearAccessToken()
     }


### PR DESCRIPTION
## Summary
- Updated SettingScreen.kt to use collectAsStateWithLifecycle instead of collectAsState
- Updated RewardListScreen.kt to use collectAsStateWithLifecycle instead of collectAsState  
- Removed TODO comment in RewardListScreen.kt that indicated wanting to make this change

## Benefits
Using collectAsStateWithLifecycle provides:
- Lifecycle awareness: Automatically pauses collection when the UI is in the background
- Memory efficiency: Reduces unnecessary work and resource usage
- Safer collection: Prevents memory leaks and crashes from collecting flows when the UI is not visible

## Reference
- https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda

## Test plan
- [x] Updated imports from `androidx.compose.runtime.collectAsState` to `androidx.lifecycle.compose.collectAsStateWithLifecycle` 
- [x] Updated function calls from `collectAsState()` to `collectAsStateWithLifecycle()`
- [x] Verified no remaining `collectAsState` usage in Compose files
- [ ] Build and test the application to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)