### PR TITLE
fix: staging/release ビルドに isShrinkResources = true を追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,11 +50,13 @@ android {
             signingConfig = signingConfigs.getByName("staging")
             applicationIdSuffix = ".beta"
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             matchingFallbacks += listOf("debug")
         }
         getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }


### PR DESCRIPTION
isMinifyEnabled = true が設定されているビルドタイプに isShrinkResources = true が ない場合に AGP 9.2.0 の NotShrinkingResources lint エラーが発生するため修正。 リソースの縮小を有効化することで APK サイズの削減にも寄与する。


(cherry picked from commit b58398621ed5f09487cc44e2fd16124fd63837d8)