### PR TITLE
feat(claude): add shared hooks for spotless gate and session context

### DIFF
--- a/.claude/docs/harness-status.md
+++ b/.claude/docs/harness-status.md
@@ -1,0 +1,114 @@
+# Claude Code ハーネス構成 星取表
+
+このプロジェクトで Claude Code 向けに整備されているハーネス（足場）の現状を、構成要素ごとに整理する。
+
+凡例: **◯** 導入済み / **△** 部分的 / **✗** 未導入 / **➖** このプロジェクトには不要
+
+## 1. コンテキスト層（Claude に渡す前提情報）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| `CLAUDE.md`（ルート） | ◯ | アーキテクチャ・命名規則・ビルドコマンド |
+| サブディレクトリ別 `CLAUDE.md` | ✗ | モジュール毎の文脈付与は未活用 |
+| 専用ドキュメント `docs/` | ◯ | domain-model / how-to-add-new-feature / module-dependency / di-setup |
+| 他 AI 向けドキュメント | ◯ | `GEMINI.md`, `.junie/guidelines.md` |
+| ADR（Architecture Decision Records） | ✗ | 設計判断の履歴記録なし |
+
+## 2. 設定層（settings）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| `.claude/settings.json`（チーム共有） | ✗ | 未作成 |
+| `.claude/settings.local.json`（個人） | ◯ | 51 項目 |
+| `permissions.allow` | ◯ | gradlew / gh / git / adb / MCP 等カバー |
+| `permissions.deny` | △ | 空（明示的禁止なし） |
+| `permissions.additionalDirectories` | ✗ | 別ディレクトリ参照許可なし |
+| 環境変数 `env` | ✗ | プロジェクト固有の env なし |
+| `statusLine` | ✗ | デフォルト |
+| `model` デフォルト | ✗ | CLI デフォルト |
+
+## 3. 拡張機能（プロジェクト固有の能力）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| Slash Commands `.claude/commands/` | ✗ | ディレクトリ空 |
+| Sub-agents `.claude/agents/` | ✗ | ディレクトリ非存在 |
+| Skills `.claude/skills/` | ✗ | ディレクトリ非存在 |
+| Output Styles | ✗ | デフォルトのみ |
+| Plugins | ✗ | 未導入 |
+
+## 4. Hooks（イベント駆動）
+
+| 要素 | 状況 | 想定用途 |
+|------|:----:|------|
+| `PreToolUse` | ✗ | git commit 前の spotlessCheck 等 |
+| `PostToolUse` | ✗ | Edit 後の自動 format 等 |
+| `UserPromptSubmit` | ✗ | プロンプトに context 自動注入 |
+| `SessionStart` | ✗ | ブランチ・CI 状況の表示 |
+| `Stop` | ✗ | 終了時のリマインダー |
+| `SubagentStop` | ✗ | サブエージェント結果の後処理 |
+| `Notification` | ✗ | 通知カスタマイズ |
+| `PreCompact` | ✗ | 文脈圧縮前の重要情報保存 |
+
+## 5. MCP（外部システム連携）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| プロジェクト `.mcp.json` | ✗ | チーム共有 MCP 設定なし |
+| Android MCP | ◯ | adb 操作・スクリーンショット（ユーザー設定経由） |
+| Todoist MCP | ◯ | アプリドメインと一致 |
+| 他カスタム MCP | ✗ | Gradle / Roborazzi 専用 MCP 等は未検討 |
+
+## 6. 品質ゲート（Claude と独立した検証）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| GitHub Actions CI | ◯ | 9 workflows |
+| spotless / detekt 設定 | ◯ | gradle plugin 導入済み |
+| Git pre-commit hooks（lefthook / husky） | ✗ | CI 失敗で初めて発覚 |
+| Conventional Commits 自動強制 | ✗ | CLAUDE.md で言及のみ |
+| commit-msg 検証 | ✗ | なし |
+
+## 7. 自動化・スケジューリング
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| `/schedule`（cron 定期実行） | ✗ | 未活用 |
+| `/loop`（自己ペース反復） | ✗ | 利用場面なし |
+| Background tasks | ➖ | アドホック使用は可 |
+| Remote triggers | ✗ | 外部起動なし |
+
+## 8. メモリ・永続化
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| ファイルメモリ（`~/.claude/projects/.../memory/`） | △ | 仕組みはあるが蓄積実績未確認 |
+| プラン履歴（`~/.claude/plans/`） | ◯ | 自動蓄積 |
+| メモリ運用ルール明文化 | ✗ | 命名規則・トリガーなし |
+
+## 9. ユーザーレベルで既に使える資産（プロジェクト共通）
+
+| 要素 | 状況 | 備考 |
+|------|:----:|------|
+| `implement` skill | ◯ | feature ブランチ + 小コミット |
+| `maestro-e2e` skill | ◯ | E2E テスト作成 |
+| `fix-ci` skill | ◯ | CI 失敗の自動診断 |
+| `review` / `security-review` skill | ◯ | PR レビュー |
+| `simplify` skill | ◯ | コード簡略化 |
+| `claude-api` / `blog-writer` 等 | ➖ | このプロジェクトと無関係 |
+
+---
+
+## サマリー
+
+**強い領域**
+- コンテキスト層（CLAUDE.md + docs/ 4 本）
+- CI/CD と Lint/Format 設定
+- permissions allowlist
+
+**弱い領域**
+- Hooks ゼロ
+- Commands / Agents / Skills ゼロ（プロジェクト固有）
+- 共有 `settings.json` なし
+- git pre-commit hooks なし
+- ADR / メモリ運用ルールなし

--- a/.claude/hooks/pre-git-commit.sh
+++ b/.claude/hooks/pre-git-commit.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash. Intercepts `git commit` and runs spotlessCheck
+# on the project before allowing the commit to proceed.
+#
+# Behavior:
+#   - exit 0: allow the tool call (no Kotlin files staged, or check passed)
+#   - exit 2: block the tool call and surface stderr to Claude
+set -uo pipefail
+
+INPUT=$(cat)
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only intercept commands that invoke `git commit`
+if ! printf '%s' "$COMMAND" | grep -qE '(^|[[:space:]]|;|&&|\|\|)git[[:space:]]+commit'; then
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$REPO_ROOT"
+
+STAGED_KT=$(git diff --cached --name-only --diff-filter=ACM | grep '\.kt$' || true)
+if [ -z "$STAGED_KT" ]; then
+  exit 0
+fi
+
+if OUTPUT=$(./gradlew --quiet spotlessCheck 2>&1); then
+  exit 0
+fi
+
+{
+  echo "❌ spotlessCheck failed before commit."
+  echo
+  printf '%s\n' "$OUTPUT" | tail -40
+  echo
+  echo "Run /format (or ./gradlew spotlessKotlinApply) to fix, then retry the commit."
+} >&2
+exit 2

--- a/.claude/hooks/session-start-context.sh
+++ b/.claude/hooks/session-start-context.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SessionStart hook. Prints a single line summarising the working state so
+# Claude can pick up cold: current branch, divergence from main, dirty file
+# count, and the most recent CI run status (when `gh` is available).
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$REPO_ROOT"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+AHEAD=$(git rev-list --count main..HEAD 2>/dev/null || echo "?")
+MODIFIED=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+CI_INFO=""
+if command -v gh >/dev/null 2>&1; then
+  CI_INFO=$(gh run list -L 1 --json status,conclusion \
+    --jq '.[0] | "CI: \(.status)/\(.conclusion // "—")"' 2>/dev/null) || CI_INFO=""
+fi
+
+LINE="📍 branch=${BRANCH} | ahead-of-main=${AHEAD} | modified=${MODIFIED}"
+if [ -n "$CI_INFO" ]; then
+  LINE="${LINE} | ${CI_INFO}"
+fi
+echo "$LINE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-git-commit.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start-context.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `.claude/settings.json` as the shared Claude Code config and register two hooks.
- `pre-git-commit.sh` (PreToolUse on Bash) blocks `git commit` when staged Kotlin files fail `spotlessCheck`, replacing the current "find out from CI" loop with a local water-line check.
- `session-start-context.sh` (SessionStart) prints branch / divergence from `main` / dirty file count / latest CI status as a single line so Claude can pick up cold.
- Add `.claude/docs/harness-status.md` — a star-table baseline of which Claude Code harness components are present, partial, or missing.

This is the first slice of a larger harness build-out (commands, agents, and a refreshed development guideline land in follow-up PRs).

## Test plan
- [x] `session-start-context.sh` prints `📍 branch=… | ahead-of-main=… | modified=… | CI: …`
- [x] `pre-git-commit.sh` exits 0 for non-`git commit` Bash invocations
- [x] `pre-git-commit.sh` exits 0 when no `*.kt` files are staged
- [ ] After merge: re-open Claude Code and confirm the SessionStart line shows up, and that intentionally breaking Spotless format then attempting a commit is blocked with the hint to run `/format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)