### PR TITLE
抽選処理中のローディング表示を追加

### DIFF
--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -189,8 +190,9 @@ private fun RewardListScreen(
                 ) {
                     if (isSingleLottering) {
                         CircularProgressIndicator(
-                            modifier = Modifier.padding(8.dp),
+                            modifier = Modifier.size(24.dp),
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            strokeWidth = 2.dp,
                         )
                     } else {
                         Icon(Icons.Filled.Done, contentDescription = "Done")
@@ -206,8 +208,9 @@ private fun RewardListScreen(
                 ) {
                     if (isBatchLottering) {
                         CircularProgressIndicator(
-                            modifier = Modifier.padding(8.dp),
+                            modifier = Modifier.size(24.dp),
                             color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            strokeWidth = 2.dp,
                         )
                     } else {
                         Text(stringResource(id = R.string.batch_lottery_button, BatchLotteryResult.DEFAULT_COUNT))

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
@@ -136,6 +137,9 @@ private fun RewardListScreen(
     val result by viewModel.result.collectAsStateWithLifecycle()
     val obtainedReward by viewModel.obtainedReward.collectAsStateWithLifecycle()
     val batchLotteryResult by viewModel.batchLotteryResult.collectAsStateWithLifecycle()
+    val isSingleLottering by viewModel.isSingleLottering.collectAsStateWithLifecycle()
+    val isBatchLottering by viewModel.isBatchLottering.collectAsStateWithLifecycle()
+    val isLottering = isSingleLottering || isBatchLottering
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -177,22 +181,36 @@ private fun RewardListScreen(
             ) {
                 FloatingActionButton(
                     onClick = {
-                        viewModel.startLottery()
+                        if (!isLottering) viewModel.startLottery()
                     },
                     shape = RoundedCornerShape(8.dp),
                     modifier = Modifier.semantics { contentDescription = "single_lottery_button" },
                 ) {
-                    Icon(Icons.Filled.Done, contentDescription = "Done")
+                    if (isSingleLottering) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(8.dp),
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    } else {
+                        Icon(Icons.Filled.Done, contentDescription = "Done")
+                    }
                 }
 
                 FloatingActionButton(
                     onClick = {
-                        viewModel.startBatchLottery()
+                        if (!isLottering) viewModel.startBatchLottery()
                     },
                     shape = RoundedCornerShape(8.dp),
                     modifier = Modifier.semantics { contentDescription = "batch_lottery_button" },
                 ) {
-                    Text(stringResource(id = R.string.batch_lottery_button, BatchLotteryResult.DEFAULT_COUNT))
+                    if (isBatchLottering) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.padding(8.dp),
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                        )
+                    } else {
+                        Text(stringResource(id = R.string.batch_lottery_button, BatchLotteryResult.DEFAULT_COUNT))
+                    }
                 }
             }
         }

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListScreen.kt
@@ -71,6 +71,7 @@ import jp.kztproject.rewardedtodo.domain.reward.RewardInput
 import jp.kztproject.rewardedtodo.domain.reward.RewardName
 import jp.kztproject.rewardedtodo.feature.reward.detail.ErrorMessageClassifier
 import jp.kztproject.rewardedtodo.presentation.reward.R
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -376,6 +377,62 @@ private val previewViewModel = RewardListViewModel(
 fun RewardListScreenPreview() {
     RewardListScreen(
         viewModel = previewViewModel,
+        onAddNewRewardClick = {},
+        onRewardItemClick = {},
+        onRewardSaveSucceeded = {},
+    )
+}
+
+private fun createLotteringPreviewViewModel(): RewardListViewModel = RewardListViewModel(
+    object : LotteryUseCase {
+        override suspend fun execute(rewards: RewardCollection): Result<Reward?> = awaitCancellation()
+    },
+    object : BatchLotteryUseCase {
+        override suspend fun execute(rewards: RewardCollection, count: Int): Result<BatchLotteryResult> =
+            awaitCancellation()
+    },
+    object : GetRewardsUseCase {
+        private val reward = Reward(
+            RewardId(1),
+            RewardName("PS5"),
+            Probability(0.5f),
+            RewardDescription(""),
+            false,
+        )
+
+        override suspend fun execute(): List<Reward> = listOf(reward)
+
+        override suspend fun executeAsFlow(): Flow<List<Reward>> = flowOf(listOf(reward))
+    },
+    object : GetPointUseCase {
+        override suspend fun execute(): Flow<NumberOfTicket> = flowOf(NumberOfTicket(100))
+    },
+    object : SaveRewardUseCase {
+        override suspend fun execute(reward: RewardInput): Result<Unit> = Result.success(Unit)
+    },
+    object : DeleteRewardUseCase {
+        override suspend fun execute(reward: Reward) {}
+    },
+)
+
+@Preview
+@Composable
+fun RewardListScreenSingleLotteringPreview() {
+    val viewModel = remember { createLotteringPreviewViewModel().apply { startLottery() } }
+    RewardListScreen(
+        viewModel = viewModel,
+        onAddNewRewardClick = {},
+        onRewardItemClick = {},
+        onRewardSaveSucceeded = {},
+    )
+}
+
+@Preview
+@Composable
+fun RewardListScreenBatchLotteringPreview() {
+    val viewModel = remember { createLotteringPreviewViewModel().apply { startBatchLottery() } }
+    RewardListScreen(
+        viewModel = viewModel,
         onAddNewRewardClick = {},
         onRewardItemClick = {},
         onRewardSaveSucceeded = {},

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
@@ -60,8 +60,8 @@ class RewardListViewModel @Inject constructor(
 
     fun startLottery() {
         if (mutableIsSingleLottering.value || mutableIsBatchLottering.value) return
+        mutableIsSingleLottering.value = true
         viewModelScope.launch {
-            mutableIsSingleLottering.value = true
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableObtainedReward.value = lotteryUseCase.execute(rewards)
@@ -78,8 +78,8 @@ class RewardListViewModel @Inject constructor(
 
     fun startBatchLottery(count: Int = BatchLotteryResult.DEFAULT_COUNT) {
         if (mutableIsSingleLottering.value || mutableIsBatchLottering.value) return
+        mutableIsBatchLottering.value = true
         viewModelScope.launch {
-            mutableIsBatchLottering.value = true
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableBatchLotteryResult.value = batchLotteryUseCase.execute(rewards, count)

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
@@ -49,16 +49,26 @@ class RewardListViewModel @Inject constructor(
     val obtainedReward = mutableObtainedReward.asStateFlow()
     private val mutableBatchLotteryResult = MutableStateFlow<Result<BatchLotteryResult>?>(null)
     val batchLotteryResult = mutableBatchLotteryResult.asStateFlow()
+    private val mutableIsSingleLottering = MutableStateFlow(false)
+    val isSingleLottering: StateFlow<Boolean> = mutableIsSingleLottering.asStateFlow()
+    private val mutableIsBatchLottering = MutableStateFlow(false)
+    val isBatchLottering: StateFlow<Boolean> = mutableIsBatchLottering.asStateFlow()
 
     init {
         loadPoint()
     }
 
     fun startLottery() {
+        if (mutableIsSingleLottering.value || mutableIsBatchLottering.value) return
         viewModelScope.launch {
-            val rewards = RewardCollection(rewardList.value)
-            mutableObtainedReward.value = lotteryUseCase.execute(rewards)
-            loadPoint()
+            mutableIsSingleLottering.value = true
+            try {
+                val rewards = RewardCollection(rewardList.value)
+                mutableObtainedReward.value = lotteryUseCase.execute(rewards)
+                loadPoint()
+            } finally {
+                mutableIsSingleLottering.value = false
+            }
         }
     }
 
@@ -67,10 +77,16 @@ class RewardListViewModel @Inject constructor(
     }
 
     fun startBatchLottery(count: Int = BatchLotteryResult.DEFAULT_COUNT) {
+        if (mutableIsSingleLottering.value || mutableIsBatchLottering.value) return
         viewModelScope.launch {
-            val rewards = RewardCollection(rewardList.value)
-            mutableBatchLotteryResult.value = batchLotteryUseCase.execute(rewards, count)
-            loadPoint()
+            mutableIsBatchLottering.value = true
+            try {
+                val rewards = RewardCollection(rewardList.value)
+                mutableBatchLotteryResult.value = batchLotteryUseCase.execute(rewards, count)
+                loadPoint()
+            } finally {
+                mutableIsBatchLottering.value = false
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- 抽選FAB（単発・まとめ）に通信中のスピナー表示を追加
- 通信中はFABクリックを無視し、二重起動を防止
- 通信中状態を確認できるComposeプレビューを追加

## 背景
抽選処理は `ticketRepository.consumeTicket()` でネットワーク通信を伴うが、これまでローディング表示がなく、ユーザーが通信中であることに気付かず連打してしまう余地があった。

## 変更内容
- `RewardListViewModel` に `isSingleLottering` / `isBatchLottering` の `StateFlow<Boolean>` を追加し、`startLottery()` / `startBatchLottery()` を try/finally で囲んで切替
- `RewardListScreen` で各FABを通信中は `CircularProgressIndicator` に差し替え
- 通信中プレビュー2種（`RewardListScreenSingleLotteringPreview` / `RewardListScreenBatchLotteringPreview`）を追加

## Test plan
- [x] `./gradlew :feature:reward:compileDebugKotlin` 成功
- [x] `./gradlew :feature:reward:testDebugUnitTest` 成功
- [x] `./gradlew spotlessCheck` 成功
- [x] Android Studio のプレビューで通信中UIを目視確認
- [x] 実機で抽選ボタン押下時にスピナーが表示されることを確認
- [x] 通信中に連打しても二重起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)