### PR TITLE
feat: 仕様プロンプトからDraft PRまでの開発プロセスを整備

### DIFF
--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: feature
+description: 仕様プロンプトから「仕様書作成→実装→動作確認→Draft PR作成」までを一貫実行する開発プロセス。/feature <仕様> で呼び出して使用
+user-invocable: true
+---
+
+# 機能開発オーケストレーションスキル (/feature)
+
+自然言語の仕様を受け取り、**仕様書 → 実装 → 動作確認 → Draft PR** までを一貫して進める。
+このスキルは新しい規約を作らず、既存の資産（`docs/` と `/implement` `/maestro-e2e` `/code-review`）を束ねるオーケストレーターとして振る舞う。
+
+## 入力
+
+`/feature` に続けて渡された自然言語の仕様プロンプト（例: `/feature 報酬一覧に検索機能を追加`）。
+プロンプトが曖昧で仕様書が書けない場合は、Phase 1の前に AskUserQuestion で必要最小限だけ確認する。
+
+## 全体フロー（5フェーズ / 承認ゲート2箇所）
+
+```
+Phase 0 準備      ─ ブランチ作成・ドキュメント読込・タスク登録
+Phase 1 仕様書作成 ─ docs/specs/ に仕様書を作成
+        ★ゲート1: 仕様書をユーザーがレビュー・承認するまで停止
+Phase 2 実装      ─ /implement のコミット規約でレイヤー順に実装
+Phase 3 動作確認   ─ ユニットテスト / Roborazzi / Maestro E2E
+Phase 4 品質チェック ─ spotless / lint・仕様書ステータス更新
+        ★ゲート2: 変更サマリをユーザーが承認するまで停止
+Phase 5 PR作成    ─ push して Draft PR を作成
+```
+
+**進捗管理**: 開始時に TaskCreate で5フェーズをタスク化し、各フェーズを `in_progress` / `completed` に更新する。
+
+---
+
+## Phase 0: 準備
+
+1. 関連ドキュメントを読む（実装方針の根拠になる）:
+   - `docs/domain-model.md` — ドメインモデルとビジネスルール
+   - `docs/module-dependency.md` — モジュール依存と禁止ルール
+   - `docs/how-to-add-new-feature.md` — レイヤー順の追加手順
+   - `docs/di-setup.md` — Hilt DI構成
+2. ブランチを確認する。`main` または非featureブランチにいる場合は、仕様から導いたスラッグで `feature/<slug>` を作成して切り替える（例: `feature/reward-search`）。すでにfeatureブランチ上なら、その意図がこの仕様と一致するか一言確認する。
+3. 仕様プロンプトを分析し、影響範囲（変更するモジュール・レイヤー）を Grep/Glob で特定する。
+
+---
+
+## Phase 1: 仕様書作成
+
+1. `docs/specs/_template.md` を雛形として読む。
+2. `docs/specs/<YYYY-MM-DD>-<slug>.md` を作成する（日付は今日、slugはブランチ名と揃える）。
+   - 仕様書はテンプレートの全セクションを埋める。特に **5. レイヤー別の変更方針** と **6. 受け入れ条件** は後工程の根拠になるため具体的に書く。
+   - 既存コードを調査し、参照すべき既存ファイル（類似UseCase・ViewModelなど）を明記する。
+3. 仕様書を1コミットで追加する: `Add <機能名>の仕様書`
+4. **★承認ゲート1**: 仕様書の要点（目的・要件・レイヤー別変更方針・受け入れ条件）を要約してユーザーに提示し、AskUserQuestion で承認を求める。
+   - 修正要望があれば仕様書に反映して再提示する。
+   - **承認されるまで Phase 2 に進まない。** 仕様書のステータスを `Approved` に更新してから進む。
+
+---
+
+## Phase 2: 実装
+
+`/implement` スキルのガイドラインに**厳密に**従う（細粒度コミット・プレフィックス規約）。要点:
+
+- **1ファイル1コミット**を原則とし、機能実装・DI設定・テスト・spotlessは必ず別コミットにする。
+- コミットメッセージは日本語の動詞プレフィックス（`Add` / `Update` / `Remove` / `Fix` / `Clean` / `Rename`）。
+- Clean Architecture のレイヤー順（Domain → Application → Data → Feature → DI）で積む。
+
+実装の具体手順は `docs/how-to-add-new-feature.md` と `docs/di-setup.md` のチェックリストに従うこと。
+仕様書の「レイヤー別の変更方針」を実装タスクの分解単位として使う。
+
+---
+
+## Phase 3: 動作確認
+
+仕様書の「テスト方針」と「受け入れ条件」に沿って、以下を実行する。失敗は**別コミット**で `Fix` する。
+
+1. **ユニットテスト**: 変更したモジュールに対して `./gradlew :<module>:testDebugUnitTest` を実行。
+   - 新規Interactor/ViewModelにはテストを追加する（`Add <Xxx>Test` / `Update テストを追加`）。テストデータは `test/` の `DummyCreator` を活用。
+2. **Roborazzi（UI変更がある場合のみ）**: `./gradlew compareRoborazziDebug` で差分を確認。
+   - 差分が仕様通りの意図的な変更なら `./gradlew recordRoborazziDebug` でゴールデン画像を更新し、別コミットで記録する。
+3. **Maestro E2E**: `/maestro-e2e` スキルを使い、`maestro-tests/<name>-flow.yaml` に受け入れ条件を検証するフローを追加（または既存フローを更新）して実行する。
+   - `appId` は `jp.kztproject.rewardedtodo.debug`。既存フロー（例: `single-lottery-flow.yaml`）の書き方に倣う。
+
+各確認の結果（pass/fail・実行コマンド）は Phase 5 のPR本文に転記できるよう記録しておく。
+
+---
+
+## Phase 4: 品質チェック
+
+1. `./gradlew spotlessKotlinApply` を実行し、整形を**別コミット** `Clean spotless適用` で記録する。
+2. `./gradlew lintDebug` を実行し、新規warningがあれば解消する。
+3. 仕様書のステータスを `Implemented` に更新してコミットする。
+
+---
+
+## Phase 5: PR作成
+
+1. **★承認ゲート2**: 次をまとめてユーザーに提示し、AskUserQuestion でPR作成の承認を求める。
+   - コミット一覧（`git log --oneline main..HEAD`）
+   - 動作確認の結果（ユニット / Roborazzi / Maestro）
+   - 仕様書へのリンクと未決事項
+   - **承認されるまで push しない。**
+2. 承認後、ブランチを push する: `git push -u origin <branch>`
+3. Draft PR を作成する: `gh pr create --draft`
+   - タイトル: 仕様の機能名（Conventional Commits の `feat:` 等を使用）
+   - 本文: 以下を含める
+     - `## 概要` — 目的の要約
+     - `## 仕様書` — `docs/specs/<file>.md` へのリンク
+     - `## 受け入れ条件` — 仕様書のチェックリストを転記（達成済みはチェック）
+     - `## 動作確認` — 実行したテストと結果
+     - `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+4. 作成されたPRのURLをユーザーに伝える。最終レビュー後にユーザー自身がReady化する旨を添える。
+
+---
+
+## 原則
+
+- **承認ゲートでは必ず停止する。** ゲートを飛ばして先に進まない。
+- コミットは `/implement` の細粒度規約を最優先する。「と」「および」を含むコミットは分割のサイン。
+- 仕様にない実装上の判断が必要になったら、勝手に決めずユーザーに確認する。
+- 各フェーズの根拠は `docs/` のドキュメントに置く。このスキルはそれらを参照するだけで規約を重複させない。

--- a/.claude/skills/feature/SKILL.md
+++ b/.claude/skills/feature/SKILL.md
@@ -61,7 +61,7 @@ Phase 5 PR作成    ─ push して Draft PR を作成
 `/implement` スキルのガイドラインに**厳密に**従う（細粒度コミット・プレフィックス規約）。要点:
 
 - **1ファイル1コミット**を原則とし、機能実装・DI設定・テスト・spotlessは必ず別コミットにする。
-- コミットメッセージは日本語の動詞プレフィックス（`Add` / `Update` / `Remove` / `Fix` / `Clean` / `Rename`）。
+- コミットメッセージは英語の動詞プレフィックス（`Add` / `Update` / `Remove` / `Fix` / `Clean` / `Rename`）＋日本語の本文。
 - Clean Architecture のレイヤー順（Domain → Application → Data → Feature → DI）で積む。
 
 実装の具体手順は `docs/how-to-add-new-feature.md` と `docs/di-setup.md` のチェックリストに従うこと。
@@ -101,7 +101,7 @@ Phase 5 PR作成    ─ push して Draft PR を作成
    - **承認されるまで push しない。**
 2. 承認後、ブランチを push する: `git push -u origin <branch>`
 3. Draft PR を作成する: `gh pr create --draft`
-   - タイトル: 仕様の機能名（Conventional Commits の `feat:` 等を使用）
+   - タイトル: 仕様の機能名を表す簡潔な日本語
    - 本文: 以下を含める
      - `## 概要` — 目的の要約
      - `## 仕様書` — `docs/specs/<file>.md` へのリンク

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,12 +144,15 @@ fun findBy(id: Int): Reward?
 - Only commit when:
     - ALL tests are passing
     - ALL compiler/linter warnings have been resolved
-    - Commit messages clearly state whether the commit contains structural or behavioral changes
-- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit message format. Example types:
-    - `feat:` for new features
-    - `fix:` for bug fixes
-    - `docs:` for documentation changes
-    - `refactor:` for code refactoring
-    - `test:` for adding or updating tests
-    - `chore:` for maintenance tasks
-    - See the [specification](https://www.conventionalcommits.org/en/v1.0.0/) for full details.
+- コミットメッセージは **英語の動詞プレフィックス ＋ 日本語の本文** で記述する。粒度は原則「1ファイル1コミット」とし、機能実装・DI設定・テスト・spotless適用は必ず別コミットにする。
+
+| プレフィックス | 用途 | 例 |
+|-------------|------|-----|
+| `Add` | 新規ファイル・機能の追加 | `Add 仕様書テンプレート` |
+| `Update` | 既存機能の変更・改修 | `Update RewardListViewModelに抽選通信中フラグを追加` |
+| `Remove` | コード・ファイルの削除 | `Remove 古い動画アップロード導線` |
+| `Fix` | バグ修正 | `Fix 単体テストがこける問題を修正` |
+| `Clean` | リファクタリング・整理 | `Clean spotless適用` |
+| `Rename` | 名前変更 | `Rename .java to .kt` |
+
+詳細なコミット粒度・実装順序のルールは `/implement` スキルに従う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,11 @@ The project uses 34+ modules organized by domain:
 - **Branch Strategy**: Feature branches from main, staging deployments from `stg-release/*` branches
 - **CI/CD**: GitHub Actions for testing and screenshot comparison
 
+## 開発プロセス
+
+仕様を与えて「仕様書作成 → 実装 → 動作確認 → Draft PR作成」まで一貫して進めるには、`/feature <仕様>` スキルを使う。
+5フェーズ構成で、**仕様書レビュー後**と**PR作成前**の2箇所で承認のため停止する。仕様書は `docs/specs/`（雛形: `docs/specs/_template.md`）に作成される。
+
 ## 機能実装時の参照ドキュメント
 
 新しい機能を実装する際は、実装前に以下のドキュメントを読んでください：

--- a/docs/specs/_template.md
+++ b/docs/specs/_template.md
@@ -1,0 +1,64 @@
+# <機能名> 仕様書
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | Draft / Approved / Implemented |
+| 作成日 | YYYY-MM-DD |
+| ブランチ | feature/xxx |
+| 関連Issue/PR | （あれば） |
+
+## 1. 背景・目的
+
+なぜこの機能が必要か。解決したい課題やユーザー価値を1〜3文で。
+
+## 2. 要件
+
+### 機能要件
+- （箇条書きで「何ができるようになるか」）
+
+### 非機能要件 / 制約
+- （パフォーマンス・既存仕様との整合・対応端末など。なければ「特になし」）
+
+## 3. 画面・UX
+
+- 対象画面: （例: RewardListScreen）
+- UI変更点: （追加・変更するコンポーネント）
+- 操作フロー: （ユーザーの操作手順を箇条書き）
+
+## 4. ドメインへの影響
+
+`docs/domain-model.md` を参照し、関係するドメインモデル・ビジネスルールを記載する。
+
+- 関係するエンティティ / Value Object:
+- 新規追加・変更するルール:
+
+## 5. レイヤー別の変更方針
+
+`docs/module-dependency.md` の依存ルールを守ること。変更しないレイヤーは行ごと削除してよい。
+
+| レイヤー | モジュール | 変更内容 |
+|---------|-----------|---------|
+| Domain | domain/xxx | エンティティ / リポジトリIF |
+| Application | application/xxx | UseCase IF + Interactor |
+| Data | data/xxx | Repository実装 / DAO / API |
+| Feature | feature/xxx | ViewModel / Compose Screen |
+| DI | app/di/xxx | `@Binds` 追加 |
+
+## 6. 受け入れ条件 (Acceptance Criteria)
+
+PRのDoneを判定する条件。テスト・動作確認の対象になる。
+
+- [ ] （観測可能な条件で記述する）
+- [ ]
+
+## 7. テスト方針
+
+| 種別 | 対象 |
+|------|------|
+| ユニットテスト | （Interactor / ViewModel など） |
+| Roborazzi | （対象Composable。UI変更がなければ「なし」） |
+| Maestro E2E | （`maestro-tests/<name>-flow.yaml`。新規フローか既存更新か） |
+
+## 8. 未決事項・リスク
+
+- （設計判断が必要な点、後続で対応する事項。なければ「特になし」）


### PR DESCRIPTION
## 概要

仕様を自然言語で与えると「仕様書作成 → 実装 → 動作確認 → Draft PR作成」まで一貫して進める開発プロセスを整備する。既存の `docs/` とスキル（`/implement` `/maestro-e2e` `/code-review`）を束ねるオーケストレーターとして実装し、規約の二重管理を避けた。

## 変更内容

| ファイル | 役割 |
|---------|------|
| `.claude/skills/feature/SKILL.md` | `/feature` スキル。5フェーズ・承認ゲート2箇所で仕様→Draft PRまでを実行 |
| `docs/specs/_template.md` | 仕様書テンプレート（Clean Architecture のレイヤー構成に対応） |
| `CLAUDE.md` | 「開発プロセス」節を追加し `/feature` を発見可能に |

## プロセスの流れ

```
Phase 0 準備       ─ feature/ ブランチ作成・docs/ 読込
Phase 1 仕様書作成  ─ docs/specs/<日付>-<slug>.md を生成
        ★ゲート1: 仕様書を承認するまで停止
Phase 2 実装       ─ /implement の細粒度コミット規約でレイヤー順に実装
Phase 3 動作確認    ─ ユニットテスト / Roborazzi / Maestro E2E
Phase 4 品質チェック ─ spotless / lint・仕様書ステータス更新
        ★ゲート2: 変更サマリを承認するまで push しない
Phase 5 PR作成     ─ push して Draft PR を作成
```

## 動作確認

- ドキュメント（Markdown）とSkill定義のみの追加でコード変更なし。ビルド・テストへの影響なし。
- `/feature` を実際に使うにはセッションのリロードが必要（プロジェクトSkillの新規追加のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)