### PR TITLE
Update VRT差分解消時に比較結果コメントを削除する

### DIFF
--- a/.github/workflows/screenshot-comparison-comment.yml
+++ b/.github/workflows/screenshot-comparison-comment.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Find Comment
         uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         id: fc
-        if: steps.prepare-companion-branch.outputs.comment_content != ''
         with:
           issue-number: ${{ steps.get-pull-request-number.outputs.pull_request_number }}
           comment-author: 'github-actions[bot]'
@@ -100,6 +99,16 @@ jobs:
           issue-number: ${{ steps.get-pull-request-number.outputs.pull_request_number }}
           body: ${{ steps.prepare-companion-branch.outputs.comment_content }}
           edit-mode: replace
+
+      - name: Delete comment when no diff
+        # 差分が無くなったら既存の比較結果コメントを削除する（解消が一目で分かるようにする）
+        if: >
+          steps.collect-compare-images.outputs.screenshot_compare_images == '' &&
+          steps.fc.outputs.comment-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE "/repos/${{ github.repository }}/issues/comments/${{ steps.fc.outputs.comment-id }}"
 
       - name: Cleanup outdated companion branches
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ fun findBy(id: Int): Reward?
 
 ## Commit Guideline
 
+- **作業は必ず feature ブランチを切ってから行う。`main` に直接コミットしない。** 気づかず `main` 上で作業・コミットしてしまった場合は、feature ブランチへ切り出して `main` を元のコミットへ巻き戻す。
 - Only commit when:
     - ALL tests are passing
     - ALL compiler/linter warnings have been resolved


### PR DESCRIPTION
## 概要

VRT(スクリーンショット比較)のPRコメントについて、差分が解消されたら既存の比較結果コメントを**自動削除**するようにします。spotlessのように「コメントが消える＝差分が解消された」と一目で分かる挙動を目指します。

## 背景 / 課題

従来の `screenshot-comparison-comment.yml` は、差分がある時のみコメントを作成/更新していました。一度差分が出てコメントが付くと、その後の修正で差分が無くなっても**古い差分画像を表示したままコメントが残り続ける**問題がありました。

## 変更内容

- `Find Comment` の実行条件を撤廃し、差分の有無に関わらず既存コメントを探すように変更
- 差分が無い かつ 既存コメントがある場合に、`gh api -X DELETE` でコメントを削除する `Delete comment when no diff` ステップを追加

### 挙動

| 状況 | 動作 |
|------|------|
| 差分あり | 従来通りコメントを作成/更新（画像付き） |
| 差分なし＋既存コメントあり | コメントを**削除** |
| 差分なし＋既存コメントなし | 何もしない |

## 検証についての注意

`screenshot-comparison-comment.yml` は `workflow_run` トリガーのため、**デフォルトブランチ(main)の定義が使われる**仕様です。そのため本PRのCIではこの変更は実行されず、**マージ後**に実際の差分付きPR→差分解消の流れで動作確認する必要があります。

## 補足

CLAUDE.md に「作業は必ず feature ブランチで行う」ルールを追記しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)