### PR TITLE
Add デバッグAPKをGitHub Releaseに添付・公開するGHA

### DIFF
--- a/.github/workflows/release-debug-apk.yml
+++ b/.github/workflows/release-debug-apk.yml
@@ -1,0 +1,42 @@
+name: Release Debug APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag name (e.g. debug-1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release-debug-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up JDK 17
+        uses: ./.github/actions/setup-java
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+
+      - name: Inject secrets into local.properties
+        run: echo "reward.server.url=${{ secrets.REWARD_SERVER_URL }}" >> local.properties
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Create GitHub Release with debug APK
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ inputs.tag }}" \
+            app/build/outputs/apk/debug/app-debug.apk \
+            --title "${{ inputs.tag }}" \
+            --generate-notes \
+            --target "${{ github.sha }}"


### PR DESCRIPTION
## Summary
- デバッグAPKをビルドし、GitHub Releaseに添付して公開するGHAを追加
- トリガーは `workflow_dispatch` のみ。`tag`（リリースタグ名）を入力として受け取る

## 変更内容
- `.github/workflows/release-debug-apk.yml` を新規追加
  - 既存ワークフローと同じく `setup-java` / `setup-gradle` 複合アクションを使用
  - `local.properties` に `REWARD_SERVER_URL` を注入してから `./gradlew assembleDebug` を実行
  - `gh release create` で `app/build/outputs/apk/debug/app-debug.apk` を添付し、`--generate-notes` でリリースノートを自動生成
  - `permissions: contents: write` を付与

## レビュアー向け補足
- デバッグビルドは `applicationIdSuffix = ".debug"` 付きで、デフォルトのdebug keystoreで署名されるため署名用secretは不要
- タグは入力必須。`versionName` から自動生成する形が良ければ変更可能
- 動作確認はGitHub上で `workflow_dispatch` を実行する必要があるため、ローカルでは未検証

## Test plan
- [ ] GitHub Actions上で `workflow_dispatch` を実行し、Releaseが作成され `app-debug.apk` が添付されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)