### PR TITLE
Add デバッグ署名鍵をCIとローカルで統一

### DIFF
--- a/.github/workflows/release-debug-apk.yml
+++ b/.github/workflows/release-debug-apk.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Inject secrets into local.properties
         run: echo "reward.server.url=${{ secrets.REWARD_SERVER_URL }}" >> local.properties
 
+      - name: Decode debug keystore
+        run: echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > debug.keystore
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.apk
 *.ap_
 staging.keystore
+debug.keystore
 
 # Files for the Dalvik VM
 *.dex

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
             // CIで配置した固定keystoreがあればそれで署名し、無ければ
             // 各自の ~/.android/debug.keystore（AGPデフォルト）を使う
             val debugKeystore = rootProject.file("debug.keystore")
-            if (debugKeystore.exists()) {
+            if (debugKeystore.isFile) {
                 storeFile = debugKeystore
                 storePassword = "android"
                 keyAlias = "androiddebugkey"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,17 @@ android {
             keyAlias = System.getenv("KEY_ALIAS")
             keyPassword = System.getenv("KEY_PASSWORD")
         }
+        getByName("debug") {
+            // CIで配置した固定keystoreがあればそれで署名し、無ければ
+            // 各自の ~/.android/debug.keystore（AGPデフォルト）を使う
+            val debugKeystore = rootProject.file("debug.keystore")
+            if (debugKeystore.exists()) {
+                storeFile = debugKeystore
+                storePassword = "android"
+                keyAlias = "androiddebugkey"
+                keyPassword = "android"
+            }
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- CIが出力するデバッグAPKを、ローカル(Mac)ビルドのAPKと同一署名にして、相互に上書きインストールできるようにする
- 署名鍵はMacの `~/.android/debug.keystore` を正とし、GitHub Secret経由でCIに共有する

## 背景
debug buildTypeに明示的な署名設定がなく、各マシンが自動生成する `~/.android/debug.keystore` で署名されていた。そのためローカルとCIで鍵が異なり、CI出力のAPKが署名不一致でインストールできなかった（`INSTALL_FAILED_UPDATE_INCOMPATIBLE`）。

## 変更内容
- `app/build.gradle.kts`: `debug` signingConfigを追加。リポジトリルートに `debug.keystore` があればそれで署名し、無ければローカルのAGPデフォルト鍵を使う
- `.github/workflows/release-debug-apk.yml`: Secret `DEBUG_KEYSTORE_BASE64` をデコードして配置するステップを追加
- `.gitignore`: CIで一時生成する `debug.keystore` を除外

## レビュアー向け補足
- Secret `DEBUG_KEYSTORE_BASE64`（Macの `~/.android/debug.keystore` をbase64化したもの）はリポジトリに登録済み
- debug keystoreの標準パスワード(`android`)はハードコードしているが、これは公開情報であり機密ではない
- ローカル(Mac)ビルドの署名証明書 SHA-1 が `07:AE:C3:9D:5F:53:...` で、CIで使うSecretの鍵と一致することを確認済み

## Test plan
- [ ] `Release Debug APK` ワークフローを実行し、出力APKの署名SHA-1がローカルと一致することを確認
- [ ] 既存のローカルビルドdebug版がインストールされた端末に、CI出力APKを上書きインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)