### PR TITLE
Add VRT実行時カバレッジを集約計測するJaCoCo convention pluginを追加

### DIFF
--- a/.github/workflows/vrt-coverage.yml
+++ b/.github/workflows/vrt-coverage.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   vrt-coverage:
+    permissions:
+      contents: read # for checking out the repository
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/vrt-coverage.yml
+++ b/.github/workflows/vrt-coverage.yml
@@ -1,0 +1,36 @@
+name: vrt-coverage
+
+on:
+  schedule:
+    # 毎週月曜 00:00 UTC (= 月曜 09:00 JST)
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  vrt-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up JDK
+        uses: ./.github/actions/setup-java
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Inject secrets into local.properties
+        run: echo "reward.server.url=${{ secrets.REWARD_SERVER_URL }}" >> local.properties
+
+      - name: Run VRT coverage report
+        run: ./gradlew :app:jacocoVrtReport
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vrt-coverage-report
+          path: app/build/reports/jacoco/jacocoVrtReport/
+          retention-days: 90

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.dagger.hilt)
     alias(libs.plugins.roborazzi)
     alias(libs.plugins.rewardedtodo.android.library.detekt)
+    alias(libs.plugins.rewardedtodo.android.jacoco)
 }
 
 val localProperties = Properties()

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,5 +32,9 @@ gradlePlugin {
             id = "rewardedtodo.android.library.detekt"
             implementationClass = "AndroidLibraryDetektConventionPlugin"
         }
+        register("androidJacoco") {
+            id = "rewardedtodo.android.jacoco"
+            implementationClass = "AndroidJacocoConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -145,6 +145,10 @@ abstract class AndroidJacocoConventionPlugin @Inject constructor(private val arc
 private val coverageIncludes = listOf("jp/kztproject/**")
 
 private val coverageExclusions = listOf(
+    // 非UI層 (VRT では描画されないため計測対象外にしてノイズを除く)
+    "**/data/**",
+    "**/application/**",
+    "**/domain/**",
     // Android 生成物
     "**/R.class",
     "**/R\$*.class",

--- a/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -149,6 +149,7 @@ private val coverageExclusions = listOf(
     "**/data/**",
     "**/application/**",
     "**/domain/**",
+    "**/common/database/**",
     // Android 生成物
     "**/R.class",
     "**/R\$*.class",

--- a/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -1,0 +1,170 @@
+import com.android.build.api.artifact.ScopedArtifact
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.ScopedArtifacts
+import com.android.build.api.variant.SourceDirectories
+import jp.kztproject.rewardedtodo.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * VRT(Roborazzi + Showkase の [ShowkaseParameterizedTest]) 実行時のコードカバレッジを
+ * 集約計測するための convention plugin。
+ *
+ * VRT は app モジュールの testDebugUnitTest でのみ実行されるが、撮影対象の Composable は
+ * feature/common など複数モジュールに分散している。JaCoCo エージェントはテスト中にロードされた
+ * 全クラスを計測するため、app の exec には依存モジュールのカバレッジも含まれる。
+ * よって [ScopedArtifacts.Scope.ALL] で依存モジュールのクラスごと集約し、ルートパッケージ
+ * (jp/kztproject) で絞り込んで自前コードのみをレポート対象にする。
+ *
+ * NOTE: enableUnitTestCoverage を有効にすると AGP が variant 単位の coverage report タスクも
+ * 自動生成するが、VRT 集約用には本 plugin が登録する `jacocoVrtReport` のみを使う。
+ * 計測は Showkase が集約される debug variant に固定する。
+ *
+ * Configuration cache 対応のため、タスク構成ブロック内では Project のメソッド
+ * (fileTree/zipTree/rootProject 等) を参照せず、注入した [ArchiveOperations] と
+ * 事前にローカル変数へ退避した値のみを使う。
+ */
+abstract class AndroidJacocoConventionPlugin @Inject constructor(private val archiveOperations: ArchiveOperations) :
+    Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("jacoco")
+
+        extensions.configure<JacocoPluginExtension> {
+            toolVersion = libs.findVersion("jacoco").get().requiredVersion
+        }
+
+        extensions.configure<ApplicationExtension> {
+            buildTypes.named("debug") {
+                enableUnitTestCoverage = true
+            }
+        }
+
+        // Project 依存をローカル変数へ退避 (configuration cache 対応)
+        val objectFactory: ObjectFactory = objects
+        val archiveOps = archiveOperations
+        val buildDirFile = layout.buildDirectory.get().asFile
+        // ソースは行単位 HTML 表示用。カバレッジ率の計算には影響しないため best-effort で全モジュールから集める。
+        val moduleSourceDirs: List<File> = rootProject.subprojects.flatMap { sub ->
+            listOf(
+                sub.projectDir.resolve("src/main/java"),
+                sub.projectDir.resolve("src/main/kotlin"),
+            )
+        }
+
+        val androidComponents = extensions.getByType<ApplicationAndroidComponentsExtension>()
+        androidComponents.onVariants(androidComponents.selector().withBuildType("debug")) { variant ->
+            val allJars: ListProperty<RegularFile> = objectFactory.listProperty(RegularFile::class.java)
+            val allDirectories: ListProperty<Directory> = objectFactory.listProperty(Directory::class.java)
+
+            val reportTask = tasks.register("jacocoVrtReport", JacocoReport::class) {
+                group = "verification"
+                description = "VRT(Roborazzi + Showkase) 実行時のコードカバレッジレポートを生成する"
+                dependsOn("testDebugUnitTest")
+
+                classDirectories.setFrom(
+                    allDirectories.map { dirs ->
+                        dirs.map { dir ->
+                            objectFactory.fileTree().setDir(dir)
+                                .include(coverageIncludes)
+                                .exclude(coverageExclusions)
+                        }
+                    },
+                    allJars.map { jars ->
+                        jars.map { jar ->
+                            archiveOps.zipTree(jar).matching {
+                                include(coverageIncludes)
+                                exclude(coverageExclusions)
+                            }
+                        }
+                    },
+                )
+
+                sourceDirectories.setFrom(
+                    moduleSourceDirs,
+                    variant.sources.java.toFilePaths(),
+                    variant.sources.kotlin.toFilePaths(),
+                )
+
+                // exec の出力先は AGP 設定で複数候補がありうるため build ディレクトリを横断して拾う。
+                executionData.setFrom(
+                    objectFactory.fileTree().setDir(buildDirFile)
+                        .include(
+                            "**/jacoco/testDebugUnitTest.exec",
+                            "**/outputs/unit_test_code_coverage/**/*.exec",
+                        ),
+                )
+
+                reports {
+                    html.required.set(true)
+                    xml.required.set(true)
+                    csv.required.set(false)
+                }
+            }
+
+            variant.artifacts.forScope(ScopedArtifacts.Scope.ALL)
+                .use(reportTask)
+                .toGet(
+                    ScopedArtifact.CLASSES,
+                    { _ -> allJars },
+                    { _ -> allDirectories },
+                )
+        }
+
+        tasks.withType<Test>().configureEach {
+            configure<JacocoTaskExtension> {
+                isIncludeNoLocationClasses = true
+                excludes = listOf("jdk.internal.*")
+            }
+        }
+    }
+
+    private fun SourceDirectories.Flat?.toFilePaths(): Provider<List<String>> = this
+        ?.all
+        ?.map { dirs -> dirs.map { it.asFile.path } }
+        ?: throw IllegalStateException("source directories are not available")
+}
+
+// 自前コードのみを対象にする (全モジュールが共有するルートパッケージ)。
+private val coverageIncludes = listOf("jp/kztproject/**")
+
+private val coverageExclusions = listOf(
+    // Android 生成物
+    "**/R.class",
+    "**/R\$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*_MembersInjector.class",
+    // Hilt / Dagger
+    "**/*_Factory.*",
+    "**/*_HiltModules*.*",
+    "**/Hilt_*.*",
+    "**/Dagger*Component*.*",
+    "**/*_GeneratedInjector.*",
+    "**/hilt_aggregated_deps/**",
+    // Room
+    "**/*_Impl.*",
+    // Showkase / KSP 生成物
+    "**/*Showkase*Codegen*.*",
+    "**/ShowkaseMetadata*.*",
+    // Compose コンパイラ生成の lambda 集約
+    "**/ComposableSingletons*.*",
+    // VRT テスト本体
+    "**/ShowkaseParameterizedTest*.*",
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ roborazzi = "1.63.0"
 detekt = "1.23.8"
 showkase = "1.0.5"
 timber = "5.0.1"
+jacoco = "0.8.13"
 
 [libraries]
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose" }
@@ -120,3 +121,4 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 rewardedtodo-android-library = { id = "rewardedtodo.android.library" }
 rewardedtodo-android-application-spotless = { id = "rewardedtodo.android.application.spotless" }
 rewardedtodo-android-library-detekt = { id = "rewardedtodo.android.library.detekt" }
+rewardedtodo-android-jacoco = { id = "rewardedtodo.android.jacoco" }


### PR DESCRIPTION
## 概要

VRT（Roborazzi + Showkase の `ShowkaseParameterizedTest`）実行時のコードカバレッジを集約計測するための JaCoCo convention plugin を追加します。

VRT は app モジュールの `testDebugUnitTest` でのみ実行されますが、撮影対象の Composable は feature/common など複数モジュールに分散しています。JaCoCo エージェントはテスト中にロードされた全クラスを計測するため、`ScopedArtifacts.Scope.ALL` で依存モジュールのクラスを集約し、ルートパッケージ（`jp/kztproject`）で絞り込んで自前コードのみをレポート対象にします。

## 変更内容

- **version catalog**: JaCoCo のバージョン（`0.8.13`）と plugin エイリアス `rewardedtodo-android-jacoco` を追加
- **build-logic**: VRT 実行時カバレッジを集約計測する `AndroidJacocoConventionPlugin` を追加し、`rewardedtodo.android.jacoco` として登録
- **app**: app モジュールに JaCoCo plugin を適用

## 実装上のポイント

- `ScopedArtifacts.Scope.ALL` で依存モジュールのクラス（jar / directory）を集約
- カバレッジ対象は `jp/kztproject/**` に限定し、Android 生成物・Hilt/Dagger・Room・Showkase/KSP 生成物・Compose コンパイラ生成 lambda・VRT テスト本体を除外
- Configuration cache 対応のため、タスク構成ブロック内では `Project` のメソッドを参照せず、注入した `ArchiveOperations` と事前にローカル変数へ退避した値のみを使用
- レポート生成タスク `jacocoVrtReport` を登録（HTML / XML 出力）

## 確認方法

```bash
./gradlew :app:jacocoVrtReport
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled JaCoCo code coverage for Android debug builds and added an aggregated, VRT-focused coverage report generation flow across modules.
  * Improved coverage output and reporting reliability with updated filters and unit test execution data collection.
* **CI**
  * Added a scheduled (weekly) GitHub Actions workflow (also manually runnable) to generate the VRT coverage report and upload it as an artifact for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->