### PR TITLE
chore: RenovateでKotlinエコシステムを一括アップデート

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,16 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "description": "Kotlin ecosystem",
+      "groupName": "Kotlin ecosystem",
+      "matchPackagePatterns": [
+        "^org\\.jetbrains\\.kotlin",
+        "^com\\.google\\.devtools\\.ksp"
+      ],
+      "minimumReleaseAge": "14 days",
+      "automerge": false
     }
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
       "description": "Kotlin ecosystem",
       "groupName": "Kotlin ecosystem",
       "matchPackagePatterns": [
-        "^org\\.jetbrains\\.kotlin",
+        "^org\\.jetbrains\\.kotlin($|[^x])",
         "^com\\.google\\.devtools\\.ksp"
       ],
       "minimumReleaseAge": "14 days",


### PR DESCRIPTION
## 概要

RenovateによるKotlinのアップデートが、単独更新のため他のエコシステムと連携できず失敗しやすい問題に対応する。

SimplePodcastPlayerの実績ある設定に倣い、Kotlin本体とKSPを1つのPRにまとめて更新するルールを追加した。

## 変更内容

`renovate.json5` に Kotlin ecosystem の packageRule を追加:

| 項目 | 値 | 効果 |
|------|-----|------|
| `groupName` | `Kotlin ecosystem` | Kotlin・KSPの更新を1つのPRにまとめる |
| `matchPackagePatterns` | `org.jetbrains.kotlin*`, `com.google.devtools.ksp*` | Kotlin本体とKSPプラグインを対象 |
| `minimumReleaseAge` | `14 days` | リリース直後の不安定版を避ける |
| `automerge` | `false` | 影響が大きいため手動レビュー |

## なぜこれで解決するか

KotlinコンパイラのバージョンはKSPやKotlinプラグイン群と密結合しており、バージョンが一致しないとビルドが壊れる。従来は個別PRで来ていたため単独アプデが失敗していたが、`groupName`で同一PRにまとめることでバージョン整合が取れた状態でまとめて更新・検証できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management rules to group Kotlin ecosystem-related packages under “Kotlin ecosystem”.
  * Added a 14-day minimum release age before updates are eligible.
  * Disabled automatic merging for these updates, requiring manual approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->