### PR TITLE
Update VRTのスクリーンショットをPixel4aサイズで撮影する

### DIFF
--- a/app/src/test/java/jp/kztproject/rewardedtodo/ShowkaseParameterizedTest.kt
+++ b/app/src/test/java/jp/kztproject/rewardedtodo/ShowkaseParameterizedTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
+import com.github.takahirom.roborazzi.RobolectricDeviceQualifiers
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Rule
 import org.junit.Test
@@ -14,7 +15,7 @@ import org.robolectric.annotation.GraphicsMode
 
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(sdk = [35])
+@Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.Pixel4a)
 class ShowkaseParameterizedTest(private val testCase: TestCase) {
 
     @get:Rule


### PR DESCRIPTION
## 概要

VRT（Roborazzi スクリーンショットテスト）の出力画像が `../SimplePodcastPlayer` と比べて小さい原因を調査し、設定を揃えました。

## 原因

`ShowkaseParameterizedTest` の `@Config` で Robolectric の `qualifiers` を指定しておらず、デフォルトの mdpi 小型デバイス（320×470px / density 1.0）で描画されていました。SimplePodcastPlayer は `RobolectricDeviceQualifiers.Pixel4a` を指定しているため 1080px 幅で出力されます。

## 変更内容

`@Config(sdk = [35])` → `@Config(sdk = [35], qualifiers = RobolectricDeviceQualifiers.Pixel4a)`

SimplePodcastPlayer の生成テストと同じ定数を使用しています。

## 検証

`recordRoborazziDebug` で再生成し、画像サイズが SimplePodcastPlayer と同等になることを確認しました。

| プレビュー | 変更前 | 変更後 |
|---|---|---|
| フル画面 | 320×470 | 1080×2340 |
| TodoListItem | 320×132 | 1080×275 |
| TodoDetailBottomSheet | 320×176 | 1080×485 |

`recordRoborazziDebug` / `spotlessKotlinApply` ともに BUILD SUCCESSFUL。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to include device qualifiers alongside SDK level specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->