### PR TITLE
Add HomeScreen の Compose Preview を追加（#747）

### DIFF
--- a/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -38,6 +39,24 @@ fun HomeScreen(onClickSetting: () -> Unit) {
         currentDestination = it
     }
 
+    HomeScreenContent(
+        currentDestination = currentDestination,
+        topLevelDestinations = topLevelDestinations,
+        onNavigateToDestination = onNavigateToDestination,
+        onClickSetting = onClickSetting,
+    ) { padding ->
+        RewardedTodoApp(padding, navController)
+    }
+}
+
+@Composable
+private fun HomeScreenContent(
+    currentDestination: TopLevelDestination,
+    topLevelDestinations: List<TopLevelDestination>,
+    onNavigateToDestination: (TopLevelDestination) -> Unit,
+    onClickSetting: () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
+) {
     Scaffold(
         topBar = {
             TopBar(
@@ -49,7 +68,7 @@ fun HomeScreen(onClickSetting: () -> Unit) {
             RewardedTodoBottomBar(topLevelDestinations, onNavigateToDestination)
         },
     ) { padding ->
-        RewardedTodoApp(padding, navController)
+        content(padding)
     }
 }
 
@@ -78,5 +97,39 @@ private fun NavHostController.navigateHome(route: String) {
         }
         launchSingleTop = true
         restoreState = true
+    }
+}
+
+@Composable
+@Preview(name = "TODOタブが選択された状態")
+fun HomeScreenTodoTabPreview() {
+    HomeScreenContent(
+        currentDestination = TopLevelDestination.TODO,
+        topLevelDestinations = TopLevelDestination.entries,
+        onNavigateToDestination = {},
+        onClickSetting = {},
+    ) { padding ->
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(padding),
+        )
+    }
+}
+
+@Composable
+@Preview(name = "REWARDタブが選択された状態")
+fun HomeScreenRewardTabPreview() {
+    HomeScreenContent(
+        currentDestination = TopLevelDestination.REWARD,
+        topLevelDestinations = TopLevelDestination.entries,
+        onNavigateToDestination = {},
+        onClickSetting = {},
+    ) { padding ->
+        Box(
+            Modifier
+                .fillMaxSize()
+                .padding(padding),
+        )
     }
 }

--- a/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
@@ -101,7 +101,7 @@ private fun NavHostController.navigateHome(route: String) {
 }
 
 @Composable
-@Preview(name = "TODOタブが選択された状態")
+@Preview
 fun HomeScreenTodoTabPreview() {
     HomeScreenContent(
         currentDestination = TopLevelDestination.TODO,
@@ -118,7 +118,7 @@ fun HomeScreenTodoTabPreview() {
 }
 
 @Composable
-@Preview(name = "REWARDタブが選択された状態")
+@Preview
 fun HomeScreenRewardTabPreview() {
     HomeScreenContent(
         currentDestination = TopLevelDestination.REWARD,


### PR DESCRIPTION
## 概要

Issue #747 に対応し、`HomeScreen` Composable に VRT（Visual Regression Test）カバレッジを追加しました。

Closes #747

## 変更内容

`HomeScreen.kt` を以下のように変更しました:

1. **`HomeScreenContent` を切り出し**: Scaffold + TopBar + BottomBar を担当する stateless な private Composable に抽出
2. **Compose Preview を追加**: 以下の 2 状態の Preview 関数を追加

## 追加した Preview 一覧

| Preview 名 | 状態 |
|---|---|
| `HomeScreenTodoTabPreview` | TODO タブが選択された状態（デフォルト） |
| `HomeScreenRewardTabPreview` | REWARD タブが選択された状態 |

## VRT 確認結果

`recordRoborazziDebug` → `compareRoborazziDebug` を実行し、以下の画像が `app/screenshots/` 配下に新規生成されたことを確認済みです:

- `TODOタブが選択された状態_Default_Group.png`
- `REWARDタブが選択された状態_Default_Group.png`

`compareRoborazziDebug` の実行結果は BUILD SUCCESSFUL でした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized home screen layout structure for improved code maintainability.

* **Tests**
  * Added preview configurations to support development and testing of different navigation states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->