### PR TITLE
Fix BottomBarのタブ選択状態がUIに反映されない問題を修正

### DIFF
--- a/app/src/main/java/jp/kztproject/rewardedtodo/RewardedTodoBottomBar.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/RewardedTodoBottomBar.kt
@@ -12,13 +12,13 @@ import androidx.compose.ui.tooling.preview.Preview
 @Composable
 fun RewardedTodoBottomBar(
     topLevelDestinations: List<TopLevelDestination>,
+    currentDestination: TopLevelDestination,
     onNavigateToDestination: (TopLevelDestination) -> Unit,
 ) {
     NavigationBar {
         topLevelDestinations.forEach { destination ->
             NavigationBarItem(
-                // FIXME reference appropriate value
-                selected = true,
+                selected = destination == currentDestination,
                 onClick = { onNavigateToDestination(destination) },
                 label = { Text(stringResource(destination.iconTextId)) },
                 icon = {
@@ -37,6 +37,7 @@ fun RewardedTodoBottomBar(
 fun RewardedTodoBottomBarPreview() {
     RewardedTodoBottomBar(
         topLevelDestinations = TopLevelDestination.entries,
+        currentDestination = TopLevelDestination.TODO,
         onNavigateToDestination = {},
     )
 }

--- a/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
@@ -7,15 +7,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import jp.kztproject.rewardedtodo.RewardedTodoBottomBar
 import jp.kztproject.rewardedtodo.TopBar
@@ -30,13 +28,16 @@ import jp.kztproject.rewardedtodo.presentation.todo.todoListScreen
 fun HomeScreen(onClickSetting: () -> Unit) {
     val navController = rememberNavController()
     val topLevelDestinations = TopLevelDestination.entries
-    var currentDestination by rememberSaveable { mutableStateOf(TopLevelDestination.TODO) }
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = when (navBackStackEntry?.destination?.route) {
+        REWARD_SCREEN -> TopLevelDestination.REWARD
+        else -> TopLevelDestination.TODO
+    }
     val onNavigateToDestination: (TopLevelDestination) -> Unit = {
         when (it) {
             TopLevelDestination.TODO -> navController.navigateHome(TODO_SCREEN)
             TopLevelDestination.REWARD -> navController.navigateHome(REWARD_SCREEN)
         }
-        currentDestination = it
     }
 
     HomeScreenContent(

--- a/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeScreen.kt
@@ -65,7 +65,7 @@ private fun HomeScreenContent(
             )
         },
         bottomBar = {
-            RewardedTodoBottomBar(topLevelDestinations, onNavigateToDestination)
+            RewardedTodoBottomBar(topLevelDestinations, currentDestination, onNavigateToDestination)
         },
     ) { padding ->
         content(padding)


### PR DESCRIPTION
## 概要

BottomBar の選択状態が常に `selected = true` でハードコードされており、現在表示中のタブが正しくハイライトされない問題を修正しました。

## 変更内容

- `RewardedTodoBottomBar` に `currentDestination` パラメータを追加し、`selected = destination == currentDestination` で現在のタブだけがハイライトされるようにした
- `HomeScreen` から `currentDestination` を渡すように更新
- Preview に `currentDestination = TopLevelDestination.TODO` を指定

## 動作確認

- ビルドが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the bottom navigation bar selection so it highlights the currently active screen based on the active navigation destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->