### PR TITLE
Add VRT for SettingScreen (missing state coverage)

### DIFF
--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
@@ -250,7 +250,7 @@ private fun ConnectionStatusCard(isConnected: Boolean) {
 }
 
 @Composable
-@Preview(name = "Disconnected State")
+@Preview
 fun SettingScreenPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = false,
@@ -262,7 +262,7 @@ fun SettingScreenPreview() {
 }
 
 @Composable
-@Preview(name = "Connected State")
+@Preview
 fun SettingScreenConnectedPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = true,
@@ -274,7 +274,7 @@ fun SettingScreenConnectedPreview() {
 }
 
 @Composable
-@Preview(name = "Disconnected State - Token Input Entered")
+@Preview
 fun SettingScreenTokenInputPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = false,
@@ -286,7 +286,7 @@ fun SettingScreenTokenInputPreview() {
 }
 
 @Composable
-@Preview(name = "Disconnected State - Validation Error")
+@Preview
 fun SettingScreenValidationErrorPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = false,
@@ -301,7 +301,7 @@ fun SettingScreenValidationErrorPreview() {
 }
 
 @Composable
-@Preview(name = "Disconnected State - Verifying")
+@Preview
 fun SettingScreenVerifyingPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = false,
@@ -316,7 +316,7 @@ fun SettingScreenVerifyingPreview() {
 }
 
 @Composable
-@Preview(name = "Connected State - Disconnecting")
+@Preview
 fun SettingScreenDisconnectingPreview() {
     SettingScreenContent(
         todoistExtensionEnabled = true,

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
@@ -272,3 +272,61 @@ fun SettingScreenConnectedPreview() {
         onTokenDelete = {},
     )
 }
+
+@Composable
+@Preview(name = "Disconnected State - Token Input Entered")
+fun SettingScreenTokenInputPreview() {
+    SettingScreenContent(
+        todoistExtensionEnabled = false,
+        tokenUiState = TokenSettingsUiState(tokenInput = "sample-token-1234567890"),
+        onTokenInputChange = {},
+        onTokenValidate = {},
+        onTokenDelete = {},
+    )
+}
+
+@Composable
+@Preview(name = "Disconnected State - Validation Error")
+fun SettingScreenValidationErrorPreview() {
+    SettingScreenContent(
+        todoistExtensionEnabled = false,
+        tokenUiState = TokenSettingsUiState(
+            tokenInput = "invalid-token",
+            validationError = TokenValidationError.INVALID_TOKEN_FORMAT,
+        ),
+        onTokenInputChange = {},
+        onTokenValidate = {},
+        onTokenDelete = {},
+    )
+}
+
+@Composable
+@Preview(name = "Disconnected State - Verifying")
+fun SettingScreenVerifyingPreview() {
+    SettingScreenContent(
+        todoistExtensionEnabled = false,
+        tokenUiState = TokenSettingsUiState(
+            tokenInput = "sample-token-1234567890",
+            isLoading = true,
+        ),
+        onTokenInputChange = {},
+        onTokenValidate = {},
+        onTokenDelete = {},
+    )
+}
+
+@Composable
+@Preview(name = "Connected State - Disconnecting")
+fun SettingScreenDisconnectingPreview() {
+    SettingScreenContent(
+        todoistExtensionEnabled = true,
+        tokenUiState = TokenSettingsUiState(
+            hasToken = true,
+            isConnected = true,
+            isLoading = true,
+        ),
+        onTokenInputChange = {},
+        onTokenValidate = {},
+        onTokenDelete = {},
+    )
+}


### PR DESCRIPTION
## 概要

`SettingScreen` のVRT（Visual Regression Test）カバレッジが不十分だったため、未カバーだった6状態のうち4状態のCompose Previewを追加した。

Closes #748

## 追加したPreview

既存:
- 未接続状態・トークン未入力（`SettingScreenPreview`）
- 接続済み状態（`SettingScreenConnectedPreview`）

新規追加:
- 未接続状態・トークン入力済み（`SettingScreenTokenInputPreview`）
- 未接続状態・バリデーションエラー表示中（`SettingScreenValidationErrorPreview`）
- 未接続状態・ローディング中（接続検証中）（`SettingScreenVerifyingPreview`）
- 接続済み状態・ローディング中（切断処理中）（`SettingScreenDisconnectingPreview`）

## 動作確認

- `./gradlew recordRoborazziDebug` で新規Previewのベースライン画像（4枚）を生成
- `./gradlew compareRoborazziDebug` を実行し、差分なしで成功することを確認（ベースラインが正しく登録されたことを確認）
- `app/screenshots/` 配下に以下の新規PNGが生成されたことを確認:
  - `Disconnected_State_-_Token_Input_Entered_Default_Group.png`
  - `Disconnected_State_-_Validation_Error_Default_Group.png`
  - `Disconnected_State_-_Verifying_Default_Group.png`
  - `Connected_State_-_Disconnecting_Default_Group.png`

## Test plan

- [x] `./gradlew spotlessKotlinApply` でフォーマット適用
- [x] `./gradlew recordRoborazziDebug` でベースライン生成
- [x] `./gradlew compareRoborazziDebug` で差分なしを確認