### PR TITLE
Add ガードレール強化（pre-commitフック・VRTカバレッジ閾値・脆弱性修正の即時化）

### DIFF
--- a/.github/workflows/vrt-coverage-check.yml
+++ b/.github/workflows/vrt-coverage-check.yml
@@ -1,0 +1,40 @@
+name: vrt-coverage-check
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  vrt-coverage-verification:
+    name: Verify VRT coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up JDK
+        uses: ./.github/actions/setup-java
+
+      - name: Setup Gradle
+        uses: ./.github/actions/setup-gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Inject secrets into local.properties
+        run: echo "reward.server.url=${{ secrets.REWARD_SERVER_URL }}" >> local.properties
+
+      # VRT カバレッジが下限 (INSTRUCTION 60%) を下回ったらマージをブロックする歯止め。
+      # レポートも同時生成し、失敗時に率の内訳を追えるようにする。
+      - name: Verify VRT coverage threshold
+        run: ./gradlew :app:jacocoVrtReport :app:jacocoVrtCoverageVerification
+
+      # 失敗時に率の内訳を確認できるよう、レポートをアーティファクトとして残す。
+      - name: Upload coverage report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: vrt-coverage-report
+          path: app/build/reports/jacoco/jacocoVrtReport/
+          retention-days: 30

--- a/.github/workflows/vrt-coverage-check.yml
+++ b/.github/workflows/vrt-coverage-check.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up JDK
         uses: ./.github/actions/setup-java

--- a/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -19,6 +19,7 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension
+import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
 import org.gradle.testing.jacoco.tasks.JacocoReport
 import java.io.File
 import javax.inject.Inject
@@ -125,6 +126,62 @@ abstract class AndroidJacocoConventionPlugin @Inject constructor(private val arc
                     { _ -> allJars },
                     { _ -> allDirectories },
                 )
+
+            // カバレッジ下限の歯止め。レポートと同じ集約クラスを対象に検証する。
+            // exec/クラスは reportTask と同一だが、scoped artifact の consumer は
+            // タスクごとに必要なため専用の ListProperty を用意する。
+            val verifyJars: ListProperty<RegularFile> = objectFactory.listProperty(RegularFile::class.java)
+            val verifyDirectories: ListProperty<Directory> = objectFactory.listProperty(Directory::class.java)
+
+            val verifyTask = tasks.register("jacocoVrtCoverageVerification", JacocoCoverageVerification::class) {
+                group = "verification"
+                description = "VRT カバレッジが下限を満たすか検証する (INSTRUCTION 60%)"
+                dependsOn("testDebugUnitTest")
+
+                classDirectories.setFrom(
+                    verifyDirectories.map { dirs ->
+                        dirs.map { dir ->
+                            objectFactory.fileTree().setDir(dir)
+                                .include(coverageIncludes)
+                                .exclude(coverageExclusions)
+                        }
+                    },
+                    verifyJars.map { jars ->
+                        jars.map { jar ->
+                            archiveOps.zipTree(jar).matching {
+                                include(coverageIncludes)
+                                exclude(coverageExclusions)
+                            }
+                        }
+                    },
+                )
+
+                executionData.setFrom(
+                    objectFactory.fileTree().setDir(buildDirFile)
+                        .include(
+                            "**/jacoco/testDebugUnitTest.exec",
+                            "**/outputs/unit_test_code_coverage/**/*.exec",
+                        ),
+                )
+
+                violationRules {
+                    rule {
+                        limit {
+                            counter = "INSTRUCTION"
+                            value = "COVEREDRATIO"
+                            minimum = "0.60".toBigDecimal()
+                        }
+                    }
+                }
+            }
+
+            variant.artifacts.forScope(ScopedArtifacts.Scope.ALL)
+                .use(verifyTask)
+                .toGet(
+                    ScopedArtifact.CLASSES,
+                    { _ -> verifyJars },
+                    { _ -> verifyDirectories },
+                )
         }
 
         tasks.withType<Test>().configureEach {
@@ -150,6 +207,14 @@ private val coverageExclusions = listOf(
     "**/application/**",
     "**/domain/**",
     "**/common/database/**",
+    // ViewModel (画面に描画されず VRT では到達しない。網羅は単体テスト側の領分)
+    "**/*ViewModel.*",
+    "**/*ViewModel\$*.*",
+    // Activity / Navigation / DI / 例外 (UI ではなく VRT で撮影不可)
+    "**/*Activity.*",
+    "**/*NavigationKt.*",
+    "**/di/**",
+    "**/*Exception.*",
     // Android 生成物
     "**/R.class",
     "**/R\$*.class",
@@ -163,11 +228,14 @@ private val coverageExclusions = listOf(
     "**/Dagger*Component*.*",
     "**/*_GeneratedInjector.*",
     "**/hilt_aggregated_deps/**",
+    "**/*_HiltComponents*.*",
+    "**/*_ComponentTreeDeps*.*",
     // Room
     "**/*_Impl.*",
     // Showkase / KSP 生成物
     "**/*Showkase*Codegen*.*",
     "**/ShowkaseMetadata*.*",
+    "**/ShowkaseModule*.*",
     // Compose コンパイラ生成の lambda 集約
     "**/ComposableSingletons*.*",
     // VRT テスト本体

--- a/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -211,8 +211,11 @@ private val coverageExclusions = listOf(
     "**/*ViewModel.*",
     "**/*ViewModel\$*.*",
     // Activity / Navigation / DI / 例外 (UI ではなく VRT で撮影不可)
+    // 内部クラス・ラムダ ($*) も除外して計測対象から確実に外す。
     "**/*Activity.*",
+    "**/*Activity\$*.*",
     "**/*NavigationKt.*",
+    "**/*NavigationKt\$*.*",
     "**/di/**",
     "**/*Exception.*",
     // Android 生成物

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ pre-commit:
         fi
 
 pre-push:
-  parallel: true
+  parallel: false
   commands:
     # 静的解析（全モジュール）。重いので push 前のみ。
     detekt:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,30 @@
+# lefthook によるローカル pre-commit / pre-push フック
+# CI（GitHub Actions）の手前に置く早期フィードバック用の関所。
+pre-commit:
+  parallel: false
+  commands:
+    # Kotlin の整形を適用し、修正結果を自動で stage し直す。
+    # spotless は ratchetFrom("origin/main") のため origin/main からの差分だけが対象。
+    spotless:
+      glob: "*.kt"
+      run: ./gradlew spotlessKotlinApply
+      stage_fixed: true
+    # ステージ済み差分にシークレットが含まれていないか検査する。
+    # gitleaks 未インストール時はスキップ（CI 側の gitleaks が最終防壁）。
+    gitleaks:
+      run: >
+        if command -v gitleaks >/dev/null 2>&1; then
+          gitleaks git --pre-commit --staged --redact --verbose;
+        else
+          echo "gitleaks 未インストールのためスキップ（brew install gitleaks で有効化）";
+        fi
+
+pre-push:
+  parallel: true
+  commands:
+    # 静的解析（全モジュール）。重いので push 前のみ。
+    detekt:
+      run: ./gradlew detekt
+    # 整形漏れの最終確認（CI の spotlessKotlinCheck と同等）。
+    spotless-check:
+      run: ./gradlew spotlessKotlinCheck

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,4 +21,8 @@
       "automerge": false
     }
   ],
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": null,
+    "labels": ["security"]
+  },
 }


### PR DESCRIPTION
## 概要

プロジェクトの不足ガードレールを棚卸しし、優先度の高い3項目を実装する。CI上のチェックは充実していた一方で「ローカルの事前ゲート」「カバレッジの歯止め」「脆弱性修正の即時化」に穴があったため埋める。

## 変更内容

### 1. ローカル pre-commit / pre-push フック（lefthook）
- `lefthook.yml` を追加。CIの手前に置く早期フィードバック用の関所（CIの置き換えではない）。
- **pre-commit**: spotless整形（自動re-stage）＋ gitleaksでステージ差分のシークレット検査
- **pre-push**: detekt ＋ spotlessチェック
- 導入: `brew install lefthook gitleaks && lefthook install`

### 2. VRTカバレッジの閾値（Jacoco verification）
- 計測除外を整備し、VRTで到達し得ないクラス（ViewModel・Activity・Navigation・DI・例外・Hilt生成物）を除外。計測対象を実際に描画されるUIへ絞った（INSTRUCTION 61.5%→67.0%）。
- `jacocoVrtCoverageVerification` を追加（**INSTRUCTION 60% 下限**）。下回ったら失敗。
- `vrt-coverage-check.yml` でPR毎に検証し、率が下限を割ったらマージをブロック。

### 3. 脆弱性修正の即時化（Renovate）
- `renovate.json5` に `vulnerabilityAlerts` を追加。`minimumReleaseAge` をnull化し、CVE修正版は通常の7〜14日待機を待たず即PRを上げる。
- 役割分担: 検知=Dependabot alerts / 通常更新=Renovate＋待機 / 修正の即時化=今回追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added additional preview states for the settings screen to improve UI verification during development.

* **Chores**
  * Added a pull request gate that verifies VRT JaCoCo coverage and uploads the report when verification fails.
  * Added Git hooks to run formatting and static analysis checks before committing and pushing.
  * Configured automated vulnerability alerts for dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->