### PR TITLE
Update targetSdk/compileSdkを37に更新

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # App Configuration
-androidTargetSdkVersion = "36"
-androidCompileSdkVersion = "36"
+androidTargetSdkVersion = "37"
+androidCompileSdkVersion = "37"
 androidMinSdkVersion = "31"
 versionCode = "1"
 versionName = "0.0.3"


### PR DESCRIPTION
## 概要

`androidTargetSdkVersion` / `androidCompileSdkVersion` を `36` → `37` に更新しました。

## 変更内容

- `gradle/libs.versions.toml`
  - `androidTargetSdkVersion`: `36` → `37`
  - `androidCompileSdkVersion`: `36` → `37`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android SDK version to 37 to ensure compatibility with the latest platform updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->