### PR TITLE
Add Claude Code GitHub Actionsワークフロー

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,12 +21,12 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    name: Claude Code
+    runs-on: ubuntu-latest
+    # 公開リポジトリのため、信頼できるユーザー（OWNER / MEMBER / COLLABORATOR）の
+    # @claude コメントのみ実行する。第三者によるAPIクレジット消費を防ぐガード。
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          claude_args: |
+            --max-turns 15

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # サブスク(Pro/Max)利用: `claude setup-token` で生成したトークンを登録する。
+          # 従量課金APIキーを使う場合は anthropic_api_key に差し替える。
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,8 +31,6 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
         with:
-          # サブスク(Pro/Max)利用: `claude setup-token` で生成したトークンを登録する。
-          # 従量課金APIキーを使う場合は anthropic_api_key に差し替える。
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"


### PR DESCRIPTION
## 概要

`@claude` メンションでオンデマンドにClaude Codeを起動するGitHub Actionsワークフローを追加します。

## 公開リポジトリ向けのセキュリティ考慮

このリポジトリはPUBLICのため、以下のガードを設けています：

- **信頼ユーザー限定**: `author_association` が `OWNER` / `MEMBER` / `COLLABORATOR` のコメントのみ起動。外部の第三者(`CONTRIBUTOR` / `NONE` 等)は弾かれ、サブスク枠を消費しない
- **`pull_request_target` 不使用**: fork PRのコードをwrite権限で実行する危険な経路を回避
- **トリガー限定**: `issue_comment` / `pull_request_review_comment` の `@claude` メンションのみ（オンデマンド）
- **actionはSHAピン留め**: 既存ワークフローの作法に準拠

## 認証

サブスク(Pro/Max)枠を使う `claude_code_oauth_token` 方式を採用。

## マージ前に必要な手動作業

リポジトリSecret `CLAUDE_CODE_OAUTH_TOKEN` の登録：

```
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo kseito/RewardedTodo
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment-based automation for repository conversations, allowing eligible team members to trigger AI-assisted actions by including a specific prompt in issue or pull request review comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->