### PR TITLE
Add Issueテンプレート(バグ報告・技術的負債)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: バグ報告
+description: アプリの不具合・想定外の挙動を報告する
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。再現と修正のため、わかる範囲で記入してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 不具合の概要
+      description: どんな不具合かを簡潔に説明してください。
+      placeholder: 例）報酬の抽選後にアプリがクラッシュする
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 不具合を再現する手順を順番に記入してください。
+      placeholder: |
+        1. ○○画面を開く
+        2. △△をタップする
+        3. □□が表示される
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+      description: 本来どうなるべきかを記入してください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の挙動
+      description: 実際にどうなったかを記入してください。スクリーンショットやログがあれば添付してください。
+    validations:
+      required: true
+
+  - type: input
+    id: app-version
+    attributes:
+      label: アプリのバージョン
+      placeholder: 例）1.2.3
+    validations:
+      required: false
+
+  - type: input
+    id: device
+    attributes:
+      label: 端末 / OSバージョン
+      placeholder: 例）Pixel 8 / Android 15
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: その他、調査の参考になる情報があれば記入してください。
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,7 +1,7 @@
 name: 技術的負債 / アーキテクチャ改善
 description: リファクタリング・設計改善・非機能要件の課題
 title: "[Tech] "
-labels: ["refactoring"]
+labels: ["tech-debt"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech_debt.yml
@@ -1,0 +1,82 @@
+name: 技術的負債 / アーキテクチャ改善
+description: リファクタリング・設計改善・非機能要件の課題
+title: "[Tech] "
+labels: ["refactoring"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        アーキテクチャ改善・技術的負債の課題です。「なぜ今やるか」と「完了条件」が明確だと着手しやすくなります。
+
+  - type: input
+    id: target
+    attributes:
+      label: 対象
+      description: 対象のモジュール / クラス / レイヤーを記入してください。
+      placeholder: 例）feature/todo の TodoListViewModel、data 層全体 など
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 現状の問題点
+      description: 今の構造・実装の何がどう良くないかを記入してください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: ideal
+    attributes:
+      label: あるべき姿
+      description: 改善後にどうなっているべきかを記入してください。
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: 放置した場合の影響（なぜ今やるか）
+      description: 改善しないことで生じるコスト・リスクを記入してください。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: migration
+    attributes:
+      label: 移行方針
+      description: どのように進める想定かを選択してください。
+      options:
+        - 段階的に進める
+        - 一括で対応する
+        - 未定 / 要相談
+    validations:
+      required: false
+
+  - type: textarea
+    id: done
+    attributes:
+      label: 完了条件（Done の定義）
+      description: 何が満たされたら完了とみなすかを記入してください。
+    validations:
+      required: true
+
+  - type: dropdown
+    id: adr
+    attributes:
+      label: ADR が必要か
+      description: 設計判断を伴う場合は docs/adr/ への記録を検討してください。
+      options:
+        - 不要
+        - 必要（設計判断を伴う）
+        - 未定 / 要相談
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: 参考リンク・関連 Issue / PR などがあれば記入してください。
+    validations:
+      required: false


### PR DESCRIPTION
## 概要

GitHub の Issue Form（YAML）形式で Issue テンプレートを追加します。

## 追加したテンプレート

- **バグ報告** (`bug_report.yml`) — ラベル `bug`
  - 概要 / 再現手順 / 期待する挙動 / 実際の挙動（必須）、アプリ・端末バージョン・補足（任意）
- **技術的負債 / アーキテクチャ改善** (`tech_debt.yml`) — ラベル `refactoring`
  - 対象 / 現状の問題点 / あるべき姿 / 放置した場合の影響 / 完了条件（必須）
  - 移行方針・ADR要否を `dropdown` で選択式に。設計判断を伴うものは `docs/adr/` への記録へ誘導
- **設定** (`config.yml`) — 白紙 Issue の作成も許可（`blank_issues_enabled: true`）

## 補足

- まずはバグ報告と技術的負債の2種類で運用開始する想定です。
- `refactoring` ラベルは未作成だと自動付与されません。必要に応じて事前に作成してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured bug report issue form in Japanese with required reproduction, expected, and actual behavior fields, plus optional environment details.
  * Added a new issue form for technical debt and architecture improvement requests with guided fields and a default label.
  * Enabled blank issue creation in the issue template settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->