### PR TITLE
ViewModelのデータロードをinit{}からFlowベースへ移行

### DIFF
--- a/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeActivity.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/presentation/HomeActivity.kt
@@ -5,10 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
@@ -33,16 +29,13 @@ class HomeActivity : ComponentActivity() {
                 colorScheme = RewardedTodoScheme(isDarkTheme = isSystemInDarkTheme()),
             ) {
                 val navController = rememberNavController()
-                var todoistAuthFinished by remember { mutableStateOf(false) }
                 NavHost(navController = navController, startDestination = HOME_SCREEN) {
                     homeScreen(
                         onClickSetting = {
                             navController.navigate(SETTING_SCREEN)
                         },
                     )
-                    settingScreen(
-                        todoistAuthFinished = todoistAuthFinished,
-                    )
+                    settingScreen()
                 }
             }
         }

--- a/application/todo/src/main/java/jp/kztproject/rewardedtodo/application/todo/GetApiTokenInteractor.kt
+++ b/application/todo/src/main/java/jp/kztproject/rewardedtodo/application/todo/GetApiTokenInteractor.kt
@@ -2,10 +2,13 @@ package jp.kztproject.rewardedtodo.application.todo
 
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import jp.kztproject.rewardedtodo.domain.todo.repository.IApiTokenRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class GetApiTokenInteractor @Inject constructor(private val apiTokenRepository: IApiTokenRepository) :
     GetApiTokenUseCase {
 
     override suspend fun execute(): ApiToken? = apiTokenRepository.getToken()
+
+    override fun executeAsFlow(): Flow<ApiToken?> = apiTokenRepository.getTokenAsFlow()
 }

--- a/application/todo/src/main/java/jp/kztproject/rewardedtodo/application/todo/GetApiTokenUseCase.kt
+++ b/application/todo/src/main/java/jp/kztproject/rewardedtodo/application/todo/GetApiTokenUseCase.kt
@@ -1,8 +1,11 @@
 package jp.kztproject.rewardedtodo.application.todo
 
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
+import kotlinx.coroutines.flow.Flow
 
 interface GetApiTokenUseCase {
 
     suspend fun execute(): ApiToken?
+
+    fun executeAsFlow(): Flow<ApiToken?>
 }

--- a/data/todo/src/main/java/jp/kztproject/rewardedtodo/data/todo/ApiTokenRepository.kt
+++ b/data/todo/src/main/java/jp/kztproject/rewardedtodo/data/todo/ApiTokenRepository.kt
@@ -3,12 +3,15 @@ package jp.kztproject.rewardedtodo.data.todo
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import jp.kztproject.rewardedtodo.common.kvs.UserPreferencesKeys
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import jp.kztproject.rewardedtodo.domain.todo.repository.IApiTokenRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 import javax.inject.Inject
 
 // トークンは平文DataStoreで保存している（暗号化しない）。Android 10+のFBEでat-rest暗号化されるため
@@ -30,6 +33,11 @@ class ApiTokenRepository @Inject constructor(private val dataStore: DataStore<Pr
     }
 
     override fun getTokenAsFlow(): Flow<ApiToken?> = dataStore.data
+        // DataStore読み取り時のIOExceptionでFlowが終了し、購読側のトークン状態更新が
+        // 止まるのを防ぐ。IO以外の例外はそのまま伝播させる。
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences()) else throw exception
+        }
         .map { ApiToken.createSafely(it[UserPreferencesKeys.TODOIST_API_TOKEN]) }
 
     override suspend fun deleteToken() {

--- a/data/todo/src/main/java/jp/kztproject/rewardedtodo/data/todo/ApiTokenRepository.kt
+++ b/data/todo/src/main/java/jp/kztproject/rewardedtodo/data/todo/ApiTokenRepository.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import jp.kztproject.rewardedtodo.common.kvs.UserPreferencesKeys
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import jp.kztproject.rewardedtodo.domain.todo.repository.IApiTokenRepository
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -27,6 +28,9 @@ class ApiTokenRepository @Inject constructor(private val dataStore: DataStore<Pr
             .first()
         return ApiToken.createSafely(tokenValue)
     }
+
+    override fun getTokenAsFlow(): Flow<ApiToken?> = dataStore.data
+        .map { ApiToken.createSafely(it[UserPreferencesKeys.TODOIST_API_TOKEN]) }
 
     override suspend fun deleteToken() {
         dataStore.edit { preferences ->

--- a/docs/specs/2026-06-27-viewmodel-flow-based-load.md
+++ b/docs/specs/2026-06-27-viewmodel-flow-based-load.md
@@ -45,7 +45,7 @@
 | Domain | domain/todo | `IApiTokenRepository` に `getTokenAsFlow(): Flow<ApiToken?>` を追加 |
 | Application | application/todo | `GetApiTokenUseCase` に `executeAsFlow(): Flow<ApiToken?>` を追加、`GetApiTokenInteractor` で実装 |
 | Data | data/todo | `ApiTokenRepository.getTokenAsFlow()` を DataStore の `data` Flow をmapして実装（`.first()` を使わない） |
-| Feature | feature/todo | `TodoListViewModel`: `init{}` 廃止。`hasAuthToken` をトークンFlowから導出。ネットワーク同期(`fetchTodoListUseCase`)を `refreshTrigger`(`MutableSharedFlow`)＋`onStart`で購読駆動の副作用に。`refreshTodoList()` はトリガーへemit |
+| Feature | feature/todo | `TodoListViewModel`: `init{}` 廃止。トークンFlow(`executeAsFlow`)を起点に `flatMapLatest` でネットワーク同期(`fetchTodoListUseCase`)→DB観測する完全リアクティブ構成に。手動リフレッシュは `refreshTrigger`(`MutableSharedFlow`)＋`onStart`で駆動し、`refreshTodoList()` はトリガーへemit。未使用だった `hasAuthToken` は削除 |
 | Feature | feature/reward | `RewardListViewModel`: `init{ loadPoint() }` 廃止。`rewardPoint` を `getPointUseCase` のFlowから `stateIn(WhileSubscribed)`。抽選後の明示 `loadPoint()` 呼び出しを削除（DataStore Flowが自動emit）。`loadPoint()` メソッド削除 |
 | Feature | feature/setting | `SettingViewModel`: `init{}` 廃止。`hasAccessToken`/`tokenUiState` をトークンFlowと編集用 `MutableStateFlow` の `combine` で合成。保存/削除後の明示 `loadAccessToken()` 呼び出しを削除。`SettingScreen` の `loadAccessToken()` 呼び出しと `loadAccessToken()`/`loadCurrentToken()` を削除 |
 
@@ -82,12 +82,8 @@ val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
             }
     }
     .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
-
-val hasAuthToken: StateFlow<Boolean> =
-    getApiTokenUseCase.executeAsFlow().map { it != null }
-        .stateIn(viewModelScope, WhileSubscribed(5000), false)
 ```
-トークン変更時・購読開始時・リフレッシュ時にネットワーク同期し、その後DBを継続観測する。再表示時は `WhileSubscribed(5000)` の再購読で再同期される。
+トークン変更時・購読開始時・リフレッシュ時にネットワーク同期し、その後DBを継続観測する。再表示時は `WhileSubscribed(5000)` の再購読で再同期される。トークン有無による取得制御は `todoList` 内の `if (token != null)` 判定と `TodoRepository.sync()` 内の再チェックで完結するため、専用の `hasAuthToken` プロパティは持たない。
 
 **RewardListViewModel**
 
@@ -152,5 +148,5 @@ val tokenUiState: StateFlow<TokenSettingsUiState> =
 ## 8. 未決事項・リスク
 
 - `SettingScreen` の `todoistAuthFinished` 引数による明示リフレッシュを削除する。OAuth完了時のトークンが同一DataStoreに保存される前提（`SaveApiTokenUseCase` 経由）であれば、Flowが自動反映するため問題ない。OAuth保存経路が別系統の場合は要再検討。
-- `hasAuthToken` は現状UIで未消費だが、内部整合と将来利用のため公開Flowとして残す。
+- `hasAuthToken` は導入以来UIで未消費のデッドコードだったため削除した。トークン有無による取得制御は `todoList` 内のインライン判定と `TodoRepository.sync()` の再チェックで担保される。
 - `GetApiTokenInteractor.executeAsFlow` の専用ユニットテストは追加していない。`application:todo` モジュールにテスト依存（mockk/coroutines-test）が未設定で、実装が `apiTokenRepository.getTokenAsFlow()` への単純委譲かつ各ViewModelテストで間接的にカバーされるため。テスト基盤を整える際に追加する。

--- a/docs/specs/2026-06-27-viewmodel-flow-based-load.md
+++ b/docs/specs/2026-06-27-viewmodel-flow-based-load.md
@@ -52,37 +52,60 @@
 ### 設計詳細
 
 **TodoListViewModel**
+
+トークンFlow(`executeAsFlow()`)を最外段の `flatMapLatest` に置き、トークンの保存・削除・OAuthログインなどの変更を検知して一覧を自動再ロードする完全リアクティブ構成にする。内側に手動リフレッシュ用の `refreshTrigger` をネストする。
+
 ```kotlin
-val todoList: StateFlow<List<Todo>> = refreshTrigger
-    .onStart { emit(Unit) }                 // 購読開始で初回同期
-    .flatMapLatest {
-        flow {
-            _isRefreshing.update { true }
-            runCatching {
-                if (getApiTokenUseCase.execute() != null) fetchTodoListUseCase.execute()
-            }.onFailure { e -> Timber.e(e); _result.update { Result.failure(e) } }
-            _isRefreshing.update { false }
-            emitAll(getTodoListUseCase.execute())   // DBを継続観測
-        }
+// replay=0 で再購読時の信号再生による二重fetchを防ぎ、extraBufferCapacity=1 で購読中のtryEmitをバッファ
+private val refreshTrigger = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+
+val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
+    .flatMapLatest { token ->
+        refreshTrigger
+            .onStart { emit(Unit) }            // 購読開始で初回同期
+            .flatMapLatest {
+                flow {
+                    if (token != null) {
+                        _isRefreshing.update { true }
+                        try {
+                            fetchTodoListUseCase.execute()
+                        } catch (e: CancellationException) {
+                            throw e            // 正常キャンセルは伝播させる
+                        } catch (e: Exception) {
+                            Timber.e(e); _result.update { Result.failure(e) }
+                        } finally {
+                            _isRefreshing.update { false }
+                        }
+                    }
+                    emitAll(getTodoListUseCase.execute())   // DBを継続観測
+                }.catch { ... }                // 1サイクルの失敗で共有ストリームを終わらせない
+            }
     }
-    .catch { ... }
     .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
 
 val hasAuthToken: StateFlow<Boolean> =
     getApiTokenUseCase.executeAsFlow().map { it != null }
         .stateIn(viewModelScope, WhileSubscribed(5000), false)
 ```
-購読開始時とリフレッシュ時にネットワーク同期し、その後DBを継続観測する。再表示時は `WhileSubscribed(5000)` の再購読で再同期される。
+トークン変更時・購読開始時・リフレッシュ時にネットワーク同期し、その後DBを継続観測する。再表示時は `WhileSubscribed(5000)` の再購読で再同期される。
 
 **RewardListViewModel**
+
+ポイントは `pointRefreshTrigger`(MutableSharedFlow)を起点に `flatMapLatest` で取得する。ネットワークモード(Todoist連携時)の `getNumberOfTicket()` は1回emitして完了するワンショットFlowのため、抽選後に `pointRefreshTrigger.tryEmit(Unit)` を発火して再フェッチする（ローカルモードのDataStore Flowは継続観測で自動更新）。
+
 ```kotlin
-val rewardPoint: StateFlow<Int> =
-    flow { emitAll(getPointUseCase.execute()) }
-        .map { it.value }
-        .catch { mutableResult.value = Result.failure(it) }
-        .stateIn(viewModelScope, WhileSubscribed(5000), 0)
+private val pointRefreshTrigger = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+
+val rewardPoint: StateFlow<Int> = pointRefreshTrigger
+    .onStart { emit(Unit) }
+    .flatMapLatest {
+        // catchをflatMapLatest内に置き、1回の取得失敗で共有ストリームを終わらせない
+        flow { emitAll(getPointUseCase.execute()) }
+            .map { it.value }
+            .catch { mutableResult.value = Result.failure(it) }
+    }
+    .stateIn(viewModelScope, WhileSubscribed(5000), 0)
 ```
-抽選はチケットDataStoreを更新し、Flowが自動emitするため明示再ロードは不要。
 
 **SettingViewModel**
 ```kotlin
@@ -107,14 +130,14 @@ val tokenUiState: StateFlow<TokenSettingsUiState> =
 
 ## 6. 受け入れ条件 (Acceptance Criteria)
 
-- [ ] 3つのViewModelの `init {}` ブロックが削除されている（データロードの副作用がない）。
-- [ ] `TodoListViewModel`/`SettingViewModel` がトークンを `getApiTokenUseCase.executeAsFlow()` から購読している。
-- [ ] `RewardListViewModel.rewardPoint` が `getPointUseCase` のFlowから `stateIn(WhileSubscribed)` で合成され、抽選後に明示 `loadPoint()` を呼ばずにポイントが更新される。
-- [ ] アプリ起動時にTodo一覧・報酬一覧・ポイント・トークン接続状態が従来通り表示される。
-- [ ] プルリフレッシュ（`refreshTodoList()`）でネットワーク同期が走る。
-- [ ] トークン保存/削除後に接続状態UIが更新される。
-- [ ] 全モジュールのユニットテストがパスする。
-- [ ] Roborazziに意図しない差分が出ない。
+- [x] 3つのViewModelの `init {}` ブロックが削除されている（データロードの副作用がない）。
+- [x] `TodoListViewModel`/`SettingViewModel` がトークンを `getApiTokenUseCase.executeAsFlow()` から購読している。
+- [x] `RewardListViewModel.rewardPoint` が `getPointUseCase` のFlowから `stateIn(WhileSubscribed)` で合成され、抽選後に明示 `loadPoint()` を呼ばずにポイントが更新される（ネットワークモードは `pointRefreshTrigger` 経由で再フェッチ）。
+- [x] アプリ起動時にTodo一覧・報酬一覧・ポイント・トークン接続状態が従来通り表示される。
+- [x] プルリフレッシュ（`refreshTodoList()`）でネットワーク同期が走る。
+- [x] トークン保存/削除後に接続状態UIが更新される。
+- [x] 全モジュールのユニットテストがパスする。
+- [x] Roborazziに意図しない差分が出ない。
 
 ## 7. テスト方針
 

--- a/docs/specs/2026-06-27-viewmodel-flow-based-load.md
+++ b/docs/specs/2026-06-27-viewmodel-flow-based-load.md
@@ -2,7 +2,7 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | Approved |
+| ステータス | Implemented |
 | 作成日 | 2026-06-27 |
 | ブランチ | feature/viewmodel-flow-based-load |
 | 関連Issue/PR | #765 |
@@ -130,3 +130,4 @@ val tokenUiState: StateFlow<TokenSettingsUiState> =
 
 - `SettingScreen` の `todoistAuthFinished` 引数による明示リフレッシュを削除する。OAuth完了時のトークンが同一DataStoreに保存される前提（`SaveApiTokenUseCase` 経由）であれば、Flowが自動反映するため問題ない。OAuth保存経路が別系統の場合は要再検討。
 - `hasAuthToken` は現状UIで未消費だが、内部整合と将来利用のため公開Flowとして残す。
+- `GetApiTokenInteractor.executeAsFlow` の専用ユニットテストは追加していない。`application:todo` モジュールにテスト依存（mockk/coroutines-test）が未設定で、実装が `apiTokenRepository.getTokenAsFlow()` への単純委譲かつ各ViewModelテストで間接的にカバーされるため。テスト基盤を整える際に追加する。

--- a/docs/specs/2026-06-27-viewmodel-flow-based-load.md
+++ b/docs/specs/2026-06-27-viewmodel-flow-based-load.md
@@ -2,7 +2,7 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | Draft |
+| ステータス | Approved |
 | 作成日 | 2026-06-27 |
 | ブランチ | feature/viewmodel-flow-based-load |
 | 関連Issue/PR | #765 |

--- a/docs/specs/2026-06-27-viewmodel-flow-based-load.md
+++ b/docs/specs/2026-06-27-viewmodel-flow-based-load.md
@@ -1,0 +1,132 @@
+# ViewModelのデータロードをinit{}からFlowベースへ移行 仕様書
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | Draft |
+| 作成日 | 2026-06-27 |
+| ブランチ | feature/viewmodel-flow-based-load |
+| 関連Issue/PR | #765 |
+
+## 1. 背景・目的
+
+`TodoListViewModel` / `RewardListViewModel` / `SettingViewModel` は `init {}` ブロック内でユースケースを実行してデータをロードしている。この設計には、ナビゲーションバックスタックで画面に戻っても再実行されない、`viewModelScope` の `Dispatchers.Main.immediate` による描画との競合、データ鮮度を保証する仕組みの欠如、テスト時に `init {}` 副作用を通過させる必要がある、といった問題がある（参考: https://funkymuse.dev/posts/properly-load-data/ ）。
+
+`init {}` での副作用ロードをやめ、ユースケースを Flow で公開して `stateIn(SharingStarted.WhileSubscribed(5000))` でホットな `StateFlow` に合成する設計へ統一する。これにより、UI購読開始時にロードが走り、再表示時の鮮度は `WhileSubscribed` の再購読で担保される。
+
+## 2. 要件
+
+### 機能要件
+- 3つのViewModelの `init {}` からデータロード処理を排除する。
+- データソース（DataStore / Room）のリアクティブFlowを `stateIn(WhileSubscribed(5000))` で購読し、初期ロードを購読駆動にする。
+- 既存のUI挙動（一覧表示・ポイント表示・トークン接続状態・プルリフレッシュ・各種結果通知）を維持する。
+
+### 非機能要件 / 制約
+- `docs/module-dependency.md` の依存方向ルールを守る（`application` は `domain` のIF経由でdataを利用）。
+- ViewModelの公開API（Composeが購読しているFlow名）を可能な限り維持し、UI差分を出さない。
+- Roborazziのゴールデン画像に差分を出さない（UI変更なし）。
+
+## 3. 画面・UX
+
+- 対象画面: `TodoListScreen` / `RewardListScreen` / `SettingScreen`
+- UI変更点: なし（内部のデータロード機構のみ変更）
+- 操作フロー: 変更なし。プルリフレッシュ・トークン保存/削除・抽選後のポイント更新は従来通り動作する。
+
+## 4. ドメインへの影響
+
+`docs/domain-model.md` 参照。ドメインモデル・ビジネスルールの変更はない。データ取得経路を「one-shot suspend」から「リアクティブFlow」に切り替えるためのリポジトリIF追加のみ。
+
+- 関係するエンティティ / Value Object: `Todo`, `ApiToken`, `NumberOfTicket`
+- 新規追加・変更するルール: なし
+
+## 5. レイヤー別の変更方針
+
+| レイヤー | モジュール | 変更内容 |
+|---------|-----------|---------|
+| Domain | domain/todo | `IApiTokenRepository` に `getTokenAsFlow(): Flow<ApiToken?>` を追加 |
+| Application | application/todo | `GetApiTokenUseCase` に `executeAsFlow(): Flow<ApiToken?>` を追加、`GetApiTokenInteractor` で実装 |
+| Data | data/todo | `ApiTokenRepository.getTokenAsFlow()` を DataStore の `data` Flow をmapして実装（`.first()` を使わない） |
+| Feature | feature/todo | `TodoListViewModel`: `init{}` 廃止。`hasAuthToken` をトークンFlowから導出。ネットワーク同期(`fetchTodoListUseCase`)を `refreshTrigger`(`MutableSharedFlow`)＋`onStart`で購読駆動の副作用に。`refreshTodoList()` はトリガーへemit |
+| Feature | feature/reward | `RewardListViewModel`: `init{ loadPoint() }` 廃止。`rewardPoint` を `getPointUseCase` のFlowから `stateIn(WhileSubscribed)`。抽選後の明示 `loadPoint()` 呼び出しを削除（DataStore Flowが自動emit）。`loadPoint()` メソッド削除 |
+| Feature | feature/setting | `SettingViewModel`: `init{}` 廃止。`hasAccessToken`/`tokenUiState` をトークンFlowと編集用 `MutableStateFlow` の `combine` で合成。保存/削除後の明示 `loadAccessToken()` 呼び出しを削除。`SettingScreen` の `loadAccessToken()` 呼び出しと `loadAccessToken()`/`loadCurrentToken()` を削除 |
+
+### 設計詳細
+
+**TodoListViewModel**
+```kotlin
+val todoList: StateFlow<List<Todo>> = refreshTrigger
+    .onStart { emit(Unit) }                 // 購読開始で初回同期
+    .flatMapLatest {
+        flow {
+            _isRefreshing.update { true }
+            runCatching {
+                if (getApiTokenUseCase.execute() != null) fetchTodoListUseCase.execute()
+            }.onFailure { e -> Timber.e(e); _result.update { Result.failure(e) } }
+            _isRefreshing.update { false }
+            emitAll(getTodoListUseCase.execute())   // DBを継続観測
+        }
+    }
+    .catch { ... }
+    .stateIn(viewModelScope, WhileSubscribed(5000), emptyList())
+
+val hasAuthToken: StateFlow<Boolean> =
+    getApiTokenUseCase.executeAsFlow().map { it != null }
+        .stateIn(viewModelScope, WhileSubscribed(5000), false)
+```
+購読開始時とリフレッシュ時にネットワーク同期し、その後DBを継続観測する。再表示時は `WhileSubscribed(5000)` の再購読で再同期される。
+
+**RewardListViewModel**
+```kotlin
+val rewardPoint: StateFlow<Int> =
+    flow { emitAll(getPointUseCase.execute()) }
+        .map { it.value }
+        .catch { mutableResult.value = Result.failure(it) }
+        .stateIn(viewModelScope, WhileSubscribed(5000), 0)
+```
+抽選はチケットDataStoreを更新し、Flowが自動emitするため明示再ロードは不要。
+
+**SettingViewModel**
+```kotlin
+private val editState = MutableStateFlow(TokenEditState())  // tokenInput/isLoading/validationError
+
+val hasAccessToken: StateFlow<Boolean> =
+    getApiTokenUseCase.executeAsFlow().map { it != null }
+        .stateIn(viewModelScope, WhileSubscribed(5000), false)
+
+val tokenUiState: StateFlow<TokenSettingsUiState> =
+    combine(getApiTokenUseCase.executeAsFlow(), editState) { token, edit ->
+        TokenSettingsUiState(
+            tokenInput = edit.tokenInput,
+            hasToken = token != null,
+            isConnected = token != null,
+            isLoading = edit.isLoading,
+            validationError = edit.validationError,
+        )
+    }.stateIn(viewModelScope, WhileSubscribed(5000), TokenSettingsUiState())
+```
+保存/削除はDataStoreを更新するだけで `hasToken`/`isConnected` がFlow経由で自動更新される。`SettingScreen` の `todoistAuthFinished` 時の明示ロードも不要になる。
+
+## 6. 受け入れ条件 (Acceptance Criteria)
+
+- [ ] 3つのViewModelの `init {}` ブロックが削除されている（データロードの副作用がない）。
+- [ ] `TodoListViewModel`/`SettingViewModel` がトークンを `getApiTokenUseCase.executeAsFlow()` から購読している。
+- [ ] `RewardListViewModel.rewardPoint` が `getPointUseCase` のFlowから `stateIn(WhileSubscribed)` で合成され、抽選後に明示 `loadPoint()` を呼ばずにポイントが更新される。
+- [ ] アプリ起動時にTodo一覧・報酬一覧・ポイント・トークン接続状態が従来通り表示される。
+- [ ] プルリフレッシュ（`refreshTodoList()`）でネットワーク同期が走る。
+- [ ] トークン保存/削除後に接続状態UIが更新される。
+- [ ] 全モジュールのユニットテストがパスする。
+- [ ] Roborazziに意図しない差分が出ない。
+
+## 7. テスト方針
+
+| 種別 | 対象 |
+|------|------|
+| ユニットテスト | `TodoListViewModelTest` / `RewardListViewModelTest` / `SettingViewModelTest` を、`init{}`副作用前提から「Flowを `backgroundScope` で購読して検証」する形へ更新。`GetApiTokenInteractor` の `executeAsFlow` テストを追加 |
+| Roborazzi | 対象Composableに変更なし。`compareRoborazziDebug` で差分ゼロを確認 |
+| Maestro E2E | 既存フロー（`single-lottery-flow.yaml` 等）が引き続きパスすることを確認。新規フローは追加しない |
+
+`WhileSubscribed` のStateFlowは購読者がいないと上流を収集しないため、テストでは `backgroundScope.launch { vm.xxx.collect {} }` で購読を張ってから値を検証する。
+
+## 8. 未決事項・リスク
+
+- `SettingScreen` の `todoistAuthFinished` 引数による明示リフレッシュを削除する。OAuth完了時のトークンが同一DataStoreに保存される前提（`SaveApiTokenUseCase` 経由）であれば、Flowが自動反映するため問題ない。OAuth保存経路が別系統の場合は要再検討。
+- `hasAuthToken` は現状UIで未消費だが、内部整合と将来利用のため公開Flowとして残す。

--- a/domain/todo/src/main/java/jp/kztproject/rewardedtodo/domain/todo/repository/IApiTokenRepository.kt
+++ b/domain/todo/src/main/java/jp/kztproject/rewardedtodo/domain/todo/repository/IApiTokenRepository.kt
@@ -1,12 +1,15 @@
 package jp.kztproject.rewardedtodo.domain.todo.repository
 
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
+import kotlinx.coroutines.flow.Flow
 
 interface IApiTokenRepository {
 
     suspend fun saveToken(token: ApiToken): Result<Unit>
 
     suspend fun getToken(): ApiToken?
+
+    fun getTokenAsFlow(): Flow<ApiToken?>
 
     suspend fun deleteToken()
 

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
@@ -53,13 +53,19 @@ class RewardListViewModel @Inject constructor(
     // ポイント再取得を駆動するトリガー。抽選後など、値の変化を能動的に反映したいときに発火する。
     // ネットワークモードの getNumberOfTicket() はワンショットFlowのため、購読しっぱなしでは
     // 抽選後に再emitされない。トリガーで再フェッチして両モードに対応する。
-    private val pointRefreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+    // replay=0 にして再購読時の信号再生による二重フェッチを防ぎ、extraBufferCapacity=1 で
+    // 購読中の tryEmit を確実にバッファする。
+    private val pointRefreshTrigger = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
 
     val rewardPoint: StateFlow<Int> = pointRefreshTrigger
         .onStart { emit(Unit) }
-        .flatMapLatest { flow { emitAll(getPointUseCase.execute()) } }
-        .map { it.value }
-        .catch { mutableResult.value = Result.failure(it) }
+        .flatMapLatest {
+            // catch を flatMapLatest 内に置き、1回の取得失敗で共有ストリームを終わらせない。
+            // 外側に置くと例外で StateFlow の収集が止まり、以降のトリガーで復帰できなくなる。
+            flow { emitAll(getPointUseCase.execute()) }
+                .map { it.value }
+                .catch { mutableResult.value = Result.failure(it) }
+        }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
@@ -14,19 +14,24 @@ import jp.kztproject.rewardedtodo.domain.reward.BatchLotteryResult
 import jp.kztproject.rewardedtodo.domain.reward.Reward
 import jp.kztproject.rewardedtodo.domain.reward.RewardCollection
 import jp.kztproject.rewardedtodo.domain.reward.RewardInput
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class RewardListViewModel @Inject constructor(
     private val lotteryUseCase: LotteryUseCase,
@@ -44,7 +49,15 @@ class RewardListViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = emptyList(),
     )
-    val rewardPoint: StateFlow<Int> = flow { emitAll(getPointUseCase.execute()) }
+
+    // ポイント再取得を駆動するトリガー。抽選後など、値の変化を能動的に反映したいときに発火する。
+    // ネットワークモードの getNumberOfTicket() はワンショットFlowのため、購読しっぱなしでは
+    // 抽選後に再emitされない。トリガーで再フェッチして両モードに対応する。
+    private val pointRefreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+
+    val rewardPoint: StateFlow<Int> = pointRefreshTrigger
+        .onStart { emit(Unit) }
+        .flatMapLatest { flow { emitAll(getPointUseCase.execute()) } }
         .map { it.value }
         .catch { mutableResult.value = Result.failure(it) }
         .stateIn(
@@ -70,6 +83,7 @@ class RewardListViewModel @Inject constructor(
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableObtainedReward.value = lotteryUseCase.execute(rewards)
+                pointRefreshTrigger.tryEmit(Unit)
             } finally {
                 mutableIsSingleLottering.value = false
             }
@@ -87,6 +101,7 @@ class RewardListViewModel @Inject constructor(
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableBatchLotteryResult.value = batchLotteryUseCase.execute(rewards, count)
+                pointRefreshTrigger.tryEmit(Unit)
             } finally {
                 mutableIsBatchLottering.value = false
             }

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardListViewModel.kt
@@ -14,13 +14,15 @@ import jp.kztproject.rewardedtodo.domain.reward.BatchLotteryResult
 import jp.kztproject.rewardedtodo.domain.reward.Reward
 import jp.kztproject.rewardedtodo.domain.reward.RewardCollection
 import jp.kztproject.rewardedtodo.domain.reward.RewardInput
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -42,8 +44,14 @@ class RewardListViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = emptyList(),
     )
-    private val mutableRewardPoint = MutableStateFlow(0)
-    val rewardPoint: StateFlow<Int> = mutableRewardPoint.asStateFlow()
+    val rewardPoint: StateFlow<Int> = flow { emitAll(getPointUseCase.execute()) }
+        .map { it.value }
+        .catch { mutableResult.value = Result.failure(it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = 0,
+        )
     private val mutableResult = MutableStateFlow<Result<Unit>?>(null)
     val result: StateFlow<Result<Unit>?> = mutableResult.asStateFlow()
     private val mutableObtainedReward = MutableStateFlow<Result<Reward?>?>(null)
@@ -55,10 +63,6 @@ class RewardListViewModel @Inject constructor(
     private val mutableIsBatchLottering = MutableStateFlow(false)
     val isBatchLottering: StateFlow<Boolean> = mutableIsBatchLottering.asStateFlow()
 
-    init {
-        loadPoint()
-    }
-
     fun startLottery() {
         if (mutableIsSingleLottering.value || mutableIsBatchLottering.value) return
         mutableIsSingleLottering.value = true
@@ -66,7 +70,6 @@ class RewardListViewModel @Inject constructor(
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableObtainedReward.value = lotteryUseCase.execute(rewards)
-                loadPoint()
             } finally {
                 mutableIsSingleLottering.value = false
             }
@@ -84,7 +87,6 @@ class RewardListViewModel @Inject constructor(
             try {
                 val rewards = RewardCollection(rewardList.value)
                 mutableBatchLotteryResult.value = batchLotteryUseCase.execute(rewards, count)
-                loadPoint()
             } finally {
                 mutableIsBatchLottering.value = false
             }
@@ -103,20 +105,6 @@ class RewardListViewModel @Inject constructor(
                 mutableObtainedReward.value = Result.failure(OverMaxRewardsException())
             } else {
                 onSuccess()
-            }
-        }
-    }
-
-    fun loadPoint() {
-        viewModelScope.launch {
-            try {
-                getPointUseCase.execute().collect {
-                    mutableRewardPoint.value = it.value
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                mutableResult.value = Result.failure(e)
             }
         }
     }

--- a/feature/reward/src/test/java/jp/kztproject/rewardedtodo/feature/reward/RewardListViewModelTest.kt
+++ b/feature/reward/src/test/java/jp/kztproject/rewardedtodo/feature/reward/RewardListViewModelTest.kt
@@ -76,9 +76,9 @@ class RewardListViewModelTest {
     }
 
     @Test
-    fun testLoadPoint() = runTest {
-        viewModel.loadPoint()
+    fun testRewardPoint() = runTest {
+        val point = viewModel.rewardPoint.first { it != 0 }
 
-        assertThat(viewModel.rewardPoint.value).isEqualTo(10)
+        assertThat(point).isEqualTo(10)
     }
 }

--- a/feature/reward/src/test/java/jp/kztproject/rewardedtodo/feature/reward/RewardListViewModelTest.kt
+++ b/feature/reward/src/test/java/jp/kztproject/rewardedtodo/feature/reward/RewardListViewModelTest.kt
@@ -8,12 +8,14 @@ import jp.kztproject.rewardedtodo.application.reward.usecase.GetPointUseCase
 import jp.kztproject.rewardedtodo.application.reward.usecase.GetRewardsUseCase
 import jp.kztproject.rewardedtodo.application.reward.usecase.LotteryUseCase
 import jp.kztproject.rewardedtodo.application.reward.usecase.SaveRewardUseCase
+import jp.kztproject.rewardedtodo.domain.reward.NumberOfTicket
 import jp.kztproject.rewardedtodo.feature.reward.list.RewardListViewModel
 import jp.kztproject.rewardedtodo.test.reward.DummyCreator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -80,5 +82,30 @@ class RewardListViewModelTest {
         val point = viewModel.rewardPoint.first { it != 0 }
 
         assertThat(point).isEqualTo(10)
+    }
+
+    @Test
+    fun `rewardPoint refreshes after single lottery`() = runTest {
+        // ネットワークモードのワンショットFlowを模し、execute()呼び出しごとに異なる値を返す
+        coEvery { mockGetPointUseCase.execute() } returnsMany listOf(
+            flowOf(NumberOfTicket(10)),
+            flowOf(NumberOfTicket(9)),
+        )
+        coEvery { mockLotteryUseCase.execute(any()) } returns Result.success(null)
+        viewModel = RewardListViewModel(
+            mockLotteryUseCase,
+            mockBatchLotteryUseCase,
+            mockGetRewardsUseCase,
+            mockGetPointUseCase,
+            mockSaveRewardUseCase,
+            mockDeleteRewardUseCase,
+        )
+        val collector = backgroundScope.launch { viewModel.rewardPoint.collect {} }
+        assertThat(viewModel.rewardPoint.first { it == 10 }).isEqualTo(10)
+
+        viewModel.startLottery()
+
+        assertThat(viewModel.rewardPoint.first { it == 9 }).isEqualTo(9)
+        collector.cancel()
     }
 }

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingNavigation.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingNavigation.kt
@@ -5,10 +5,8 @@ import androidx.navigation.compose.composable
 
 const val SETTING_SCREEN = "setting_screen"
 
-fun NavGraphBuilder.settingScreen(todoistAuthFinished: Boolean) {
+fun NavGraphBuilder.settingScreen() {
     composable(SETTING_SCREEN) {
-        SettingScreen(
-            todoistAuthFinished = todoistAuthFinished,
-        )
+        SettingScreen()
     }
 }

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingScreen.kt
@@ -17,13 +17,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 
 @Composable
-fun SettingScreen(todoistAuthFinished: Boolean = false, viewModel: SettingViewModel = hiltViewModel()) {
+fun SettingScreen(viewModel: SettingViewModel = hiltViewModel()) {
     val todoistExtensionEnabled = viewModel.hasAccessToken.collectAsState()
     val tokenUiState = viewModel.tokenUiState.collectAsState()
-
-    if (todoistAuthFinished) {
-        viewModel.loadAccessToken()
-    }
 
     SettingScreenContent(
         todoistExtensionEnabled.value,

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModel.kt
@@ -7,12 +7,14 @@ import jp.kztproject.rewardedtodo.application.todo.DeleteApiTokenUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.application.todo.SaveApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.TokenError
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -80,21 +82,29 @@ class SettingViewModel @Inject constructor(
                     is TokenError.EmptyToken -> TokenValidationError.TOKEN_EMPTY
                     else -> TokenValidationError.FAILED_TO_SAVE_TOKEN
                 }
-                editState.value = currentEdit.copy(
-                    isLoading = false,
-                    validationError = validationError,
-                )
+                // currentEditではなく最新のeditStateを基準に更新し、保存中にユーザーが入力した
+                // 新しいトークンを古い値で上書きしないようにする。
+                editState.update {
+                    it.copy(isLoading = false, validationError = validationError)
+                }
             }
         }
     }
 
     fun deleteToken() {
         viewModelScope.launch {
-            editState.value = editState.value.copy(isLoading = true)
+            editState.update { it.copy(isLoading = true) }
 
-            deleteApiTokenUseCase.execute()
-            // 削除でトークンFlowが再emitされ、hasToken/isConnectedは自動更新される
-            editState.value = TokenEditState()
+            try {
+                deleteApiTokenUseCase.execute()
+                // 削除でトークンFlowが再emitされ、hasToken/isConnectedは自動更新される
+                editState.value = TokenEditState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // 削除に失敗してもローディングは必ず解除し、画面が固まらないようにする
+                editState.update { it.copy(isLoading = false) }
+            }
         }
     }
 }

--- a/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/main/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModel.kt
@@ -8,8 +8,11 @@ import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.application.todo.SaveApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.TokenError
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,58 +23,64 @@ class SettingViewModel @Inject constructor(
     private val deleteApiTokenUseCase: DeleteApiTokenUseCase,
 ) : ViewModel() {
 
-    private val mutableHasAccessToken = MutableStateFlow(false)
-    val hasAccessToken: StateFlow<Boolean> = mutableHasAccessToken
+    // トークン入力欄・ローディング・バリデーションエラーなど、ユーザー操作で変わる状態のみ保持する
+    private val editState = MutableStateFlow(TokenEditState())
 
-    private val _tokenUiState = MutableStateFlow(TokenSettingsUiState())
-    val tokenUiState: StateFlow<TokenSettingsUiState> = _tokenUiState.asStateFlow()
+    val hasAccessToken: StateFlow<Boolean> = getApiTokenUseCase.executeAsFlow()
+        .map { it != null }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false,
+        )
 
-    init {
-        loadAccessToken()
-        loadCurrentToken()
-    }
-
-    fun loadAccessToken() = viewModelScope.launch {
-        val hasApiToken = getApiTokenUseCase.execute() != null
-        mutableHasAccessToken.value = hasApiToken
-    }
+    val tokenUiState: StateFlow<TokenSettingsUiState> = combine(
+        getApiTokenUseCase.executeAsFlow(),
+        editState,
+    ) { token, edit ->
+        TokenSettingsUiState(
+            tokenInput = edit.tokenInput,
+            hasToken = token != null,
+            isConnected = token != null,
+            isLoading = edit.isLoading,
+            validationError = edit.validationError,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000),
+        initialValue = TokenSettingsUiState(),
+    )
 
     fun updateTokenInput(token: String) {
-        _tokenUiState.value = _tokenUiState.value.copy(
+        editState.value = editState.value.copy(
             tokenInput = token,
             validationError = null,
         )
     }
 
     fun saveToken() {
-        val currentState = _tokenUiState.value
-        if (currentState.tokenInput.isBlank()) {
-            _tokenUiState.value = currentState.copy(
+        val currentEdit = editState.value
+        if (currentEdit.tokenInput.isBlank()) {
+            editState.value = currentEdit.copy(
                 validationError = TokenValidationError.TOKEN_EMPTY,
             )
             return
         }
 
         viewModelScope.launch {
-            _tokenUiState.value = currentState.copy(isLoading = true, validationError = null)
+            editState.value = currentEdit.copy(isLoading = true, validationError = null)
 
-            val saveResult = saveApiTokenUseCase.execute(currentState.tokenInput)
+            val saveResult = saveApiTokenUseCase.execute(currentEdit.tokenInput)
+            // 保存に成功するとトークンFlowが再emitされ、hasToken/isConnectedは自動更新される
             if (saveResult.isSuccess) {
-                _tokenUiState.value = currentState.copy(
-                    isLoading = false,
-                    hasToken = true,
-                    isConnected = true,
-                    tokenInput = "",
-                    validationError = null,
-                )
-                loadAccessToken() // Refresh the main token status
+                editState.value = TokenEditState()
             } else {
                 val validationError = when (saveResult.exceptionOrNull()) {
                     is TokenError.InvalidFormat -> TokenValidationError.INVALID_TOKEN_FORMAT
                     is TokenError.EmptyToken -> TokenValidationError.TOKEN_EMPTY
                     else -> TokenValidationError.FAILED_TO_SAVE_TOKEN
                 }
-                _tokenUiState.value = currentState.copy(
+                editState.value = currentEdit.copy(
                     isLoading = false,
                     validationError = validationError,
                 )
@@ -81,31 +90,20 @@ class SettingViewModel @Inject constructor(
 
     fun deleteToken() {
         viewModelScope.launch {
-            _tokenUiState.value = _tokenUiState.value.copy(isLoading = true)
+            editState.value = editState.value.copy(isLoading = true)
 
             deleteApiTokenUseCase.execute()
-
-            _tokenUiState.value = _tokenUiState.value.copy(
-                isLoading = false,
-                hasToken = false,
-                isConnected = false,
-                tokenInput = "",
-                validationError = null,
-            )
-            loadAccessToken() // Refresh the main token status
-        }
-    }
-
-    private fun loadCurrentToken() {
-        viewModelScope.launch {
-            val currentToken = getApiTokenUseCase.execute()
-            _tokenUiState.value = _tokenUiState.value.copy(
-                hasToken = currentToken != null,
-                isConnected = currentToken != null,
-            )
+            // 削除でトークンFlowが再emitされ、hasToken/isConnectedは自動更新される
+            editState.value = TokenEditState()
         }
     }
 }
+
+private data class TokenEditState(
+    val tokenInput: String = "",
+    val isLoading: Boolean = false,
+    val validationError: TokenValidationError? = null,
+)
 
 data class TokenSettingsUiState(
     val tokenInput: String = "",

--- a/feature/setting/src/test/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModelTest.kt
+++ b/feature/setting/src/test/java/jp/kztproject/rewardedtodo/feature/setting/SettingViewModelTest.kt
@@ -2,6 +2,7 @@ package jp.kztproject.rewardedtodo.feature.setting
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import jp.kztproject.rewardedtodo.application.todo.DeleteApiTokenUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
@@ -10,6 +11,9 @@ import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import jp.kztproject.rewardedtodo.domain.todo.TokenError
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -25,15 +29,21 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class SettingViewModelTest {
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     private val mockGetApiTokenUseCase = mockk<GetApiTokenUseCase>()
     private val mockSaveApiTokenUseCase = mockk<SaveApiTokenUseCase>()
     private val mockDeleteApiTokenUseCase = mockk<DeleteApiTokenUseCase>(relaxed = true)
+
+    // トークンソースのリアクティブFlowをMutableStateFlowで模倣する
+    private val tokenFlow = MutableStateFlow<ApiToken?>(null)
 
     private lateinit var viewModel: SettingViewModel
 
     @Before
     fun setup() {
-        Dispatchers.setMain(UnconfinedTestDispatcher())
+        Dispatchers.setMain(testDispatcher)
+        every { mockGetApiTokenUseCase.executeAsFlow() } returns tokenFlow
     }
 
     @After
@@ -41,10 +51,26 @@ class SettingViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private fun createViewModel() = SettingViewModel(
+        mockGetApiTokenUseCase,
+        mockSaveApiTokenUseCase,
+        mockDeleteApiTokenUseCase,
+    )
+
+    // WhileSubscribedのStateFlowを購読してホット化する
+    private fun TestScope.subscribe(vm: SettingViewModel) {
+        backgroundScope.launch { vm.tokenUiState.collect {} }
+        backgroundScope.launch { vm.hasAccessToken.collect {} }
+    }
+
     @Test
-    fun `init loads access token and updates hasAccessToken state`() = runTest {
-        // Given & When
-        setupViewModelWithToken()
+    fun `hasAccessToken and tokenUiState reflect existing token`() = runTest(testDispatcher) {
+        // Given
+        tokenFlow.value = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
+        viewModel = createViewModel()
+
+        // When
+        subscribe(viewModel)
 
         // Then
         assertThat(viewModel.hasAccessToken.value).isTrue()
@@ -53,9 +79,10 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `updateTokenInput updates token input and clears validation error`() = runTest {
+    fun `updateTokenInput updates token input and clears validation error`() = runTest(testDispatcher) {
         // Given
-        setupViewModelWithNoInitialToken()
+        viewModel = createViewModel()
+        subscribe(viewModel)
 
         // When
         viewModel.updateTokenInput("new_token")
@@ -66,9 +93,10 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `saveToken with blank input shows TOKEN_EMPTY error`() = runTest {
+    fun `saveToken with blank input shows TOKEN_EMPTY error`() = runTest(testDispatcher) {
         // Given
-        setupViewModelWithNoInitialToken()
+        viewModel = createViewModel()
+        subscribe(viewModel)
         viewModel.updateTokenInput("   ")
 
         // When
@@ -82,17 +110,15 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `saveToken with valid token succeeds`() = runTest {
+    fun `saveToken with valid token succeeds`() = runTest(testDispatcher) {
         // Given
         val testToken = "0123456789abcdef0123456789abcdef01234567"
-        val apiToken = ApiToken.createSafely(testToken)
-        coEvery { mockGetApiTokenUseCase.execute() } returns null andThen apiToken
-        coEvery { mockSaveApiTokenUseCase.execute(testToken) } returns Result.success(Unit)
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
+        coEvery { mockSaveApiTokenUseCase.execute(testToken) } coAnswers {
+            tokenFlow.value = ApiToken.create(testToken)
+            Result.success(Unit)
+        }
+        viewModel = createViewModel()
+        subscribe(viewModel)
         viewModel.updateTokenInput(testToken)
 
         // When
@@ -109,11 +135,12 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `saveToken with InvalidFormat error shows INVALID_TOKEN_FORMAT error`() = runTest {
+    fun `saveToken with InvalidFormat error shows INVALID_TOKEN_FORMAT error`() = runTest(testDispatcher) {
         // Given
         coEvery { mockSaveApiTokenUseCase.execute("invalid_token") } returns
             Result.failure(TokenError.InvalidFormat())
-        setupViewModelWithNoInitialToken()
+        viewModel = createViewModel()
+        subscribe(viewModel)
         viewModel.updateTokenInput("invalid_token")
 
         // When
@@ -127,11 +154,12 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `saveToken with EmptyToken error shows TOKEN_EMPTY error`() = runTest {
+    fun `saveToken with EmptyToken error shows TOKEN_EMPTY error`() = runTest(testDispatcher) {
         // Given
         coEvery { mockSaveApiTokenUseCase.execute("token") } returns
             Result.failure(TokenError.EmptyToken())
-        setupViewModelWithNoInitialToken()
+        viewModel = createViewModel()
+        subscribe(viewModel)
         viewModel.updateTokenInput("token")
 
         // When
@@ -144,11 +172,12 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `saveToken with unknown error shows FAILED_TO_SAVE_TOKEN error`() = runTest {
+    fun `saveToken with unknown error shows FAILED_TO_SAVE_TOKEN error`() = runTest(testDispatcher) {
         // Given
         coEvery { mockSaveApiTokenUseCase.execute("token") } returns
             Result.failure(Exception("Unknown error"))
-        setupViewModelWithNoInitialToken()
+        viewModel = createViewModel()
+        subscribe(viewModel)
         viewModel.updateTokenInput("token")
 
         // When
@@ -161,15 +190,12 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `deleteToken removes token and updates states`() = runTest {
+    fun `deleteToken removes token and updates states`() = runTest(testDispatcher) {
         // Given
-        val testToken = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
-        coEvery { mockGetApiTokenUseCase.execute() } returns testToken andThen null
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
+        tokenFlow.value = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
+        coEvery { mockDeleteApiTokenUseCase.execute() } coAnswers { tokenFlow.value = null }
+        viewModel = createViewModel()
+        subscribe(viewModel)
 
         // When
         viewModel.deleteToken()
@@ -185,58 +211,32 @@ class SettingViewModelTest {
     }
 
     @Test
-    fun `loadAccessToken updates hasAccessToken when token exists`() = runTest {
+    fun `hasAccessToken becomes true when token flow emits a token`() = runTest(testDispatcher) {
         // Given
-        val testToken = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
-        coEvery { mockGetApiTokenUseCase.execute() } returns null andThen testToken
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
+        tokenFlow.value = null
+        viewModel = createViewModel()
+        subscribe(viewModel)
+        assertThat(viewModel.hasAccessToken.value).isFalse()
 
         // When
-        viewModel.loadAccessToken()
+        tokenFlow.value = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
 
         // Then
         assertThat(viewModel.hasAccessToken.value).isTrue()
     }
 
     @Test
-    fun `loadAccessToken updates hasAccessToken when token does not exist`() = runTest {
+    fun `hasAccessToken becomes false when token flow emits null`() = runTest(testDispatcher) {
         // Given
-        val testToken = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
-        coEvery { mockGetApiTokenUseCase.execute() } returns testToken andThen null
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
+        tokenFlow.value = ApiToken.createSafely("0123456789abcdef0123456789abcdef01234567")
+        viewModel = createViewModel()
+        subscribe(viewModel)
+        assertThat(viewModel.hasAccessToken.value).isTrue()
 
         // When
-        viewModel.loadAccessToken()
+        tokenFlow.value = null
 
         // Then
         assertThat(viewModel.hasAccessToken.value).isFalse()
-    }
-
-    private fun setupViewModelWithNoInitialToken() {
-        coEvery { mockGetApiTokenUseCase.execute() } returns null
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
-    }
-
-    private fun setupViewModelWithToken() {
-        val testToken = "0123456789abcdef0123456789abcdef01234567"
-        val apiToken = ApiToken.createSafely(testToken)
-        coEvery { mockGetApiTokenUseCase.execute() } returns apiToken
-        viewModel = SettingViewModel(
-            mockGetApiTokenUseCase,
-            mockSaveApiTokenUseCase,
-            mockDeleteApiTokenUseCase,
-        )
     }
 }

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListScreen.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListScreen.kt
@@ -198,6 +198,7 @@ fun TodoListScreenPreview() {
         },
         object : GetApiTokenUseCase {
             override suspend fun execute(): ApiToken? = null
+            override fun executeAsFlow(): Flow<ApiToken?> = flowOf(null)
         },
     )
     TodoListScreen(

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -9,10 +9,12 @@ import jp.kztproject.rewardedtodo.application.reward.FetchTodoListUseCase
 import jp.kztproject.rewardedtodo.application.reward.GetTodoListUseCase
 import jp.kztproject.rewardedtodo.application.reward.UpdateTodoUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
+import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import jp.kztproject.rewardedtodo.domain.todo.EditingTodo
 import jp.kztproject.rewardedtodo.domain.todo.Todo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -54,41 +56,44 @@ class TodoListViewModel @Inject constructor(
 
     // トークン変更を起点にネットワーク同期し、その後DBを継続観測する完全リアクティブな一覧
     val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
-        .flatMapLatest { token ->
-            // 初回ロード(onStart)は false、手動プルリフレッシュ(refreshTrigger)は true。
-            // プルリフレッシュ用スピナーは手動時のみ表示し、初回ロードでは出さない。
-            refreshTrigger
-                .map { true }
-                .onStart { emit(false) }
-                .flatMapLatest { isManualRefresh ->
-                    flow {
-                        if (token != null) {
-                            if (isManualRefresh) _isRefreshing.update { true }
-                            try {
-                                fetchTodoListUseCase.execute()
-                            } catch (e: CancellationException) {
-                                throw e
-                            } catch (e: Exception) {
-                                Timber.e(e)
-                                _result.update { Result.failure(e) }
-                            } finally {
-                                if (isManualRefresh) _isRefreshing.update { false }
-                            }
-                        }
-                        emitAll(getTodoListUseCase.execute())
-                    }
-                        // 1サイクルの失敗で共有ストリームを終わらせない（次のリフレッシュで復帰可能にする）
-                        .catch { throwable ->
-                            Timber.e(throwable)
-                            _result.update { Result.failure(throwable) }
-                        }
-                }
-        }
+        .flatMapLatest { token -> syncThenObserveTodoList(token) }
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
             initialValue = emptyList(),
         )
+
+    // 初回ロード(onStart)と手動リフレッシュ(refreshTrigger)を契機に同期し、その後DBを観測する。
+    // 初回ロードは false、手動プルリフレッシュは true として扱い、スピナーは手動時のみ表示する。
+    private fun syncThenObserveTodoList(token: ApiToken?): Flow<List<Todo>> = refreshTrigger
+        .map { true }
+        .onStart { emit(false) }
+        .flatMapLatest { isManualRefresh ->
+            flow {
+                if (token != null) syncTodoList(isManualRefresh)
+                emitAll(getTodoListUseCase.execute())
+            }
+                // 1サイクルの失敗で共有ストリームを終わらせない（次のリフレッシュで復帰可能にする）
+                .catch { reportError(it) }
+        }
+
+    private suspend fun syncTodoList(isManualRefresh: Boolean) {
+        if (isManualRefresh) _isRefreshing.update { true }
+        try {
+            fetchTodoListUseCase.execute()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            reportError(e)
+        } finally {
+            if (isManualRefresh) _isRefreshing.update { false }
+        }
+    }
+
+    private fun reportError(throwable: Throwable) {
+        Timber.e(throwable)
+        _result.update { Result.failure(throwable) }
+    }
 
     fun refreshTodoList() {
         refreshTrigger.tryEmit(Unit)

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -11,6 +11,7 @@ import jp.kztproject.rewardedtodo.application.reward.UpdateTodoUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.EditingTodo
 import jp.kztproject.rewardedtodo.domain.todo.Todo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -54,8 +55,10 @@ class TodoListViewModel @Inject constructor(
             initialValue = false,
         )
 
-    // プルリフレッシュによる手動同期を駆動するトリガー
-    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+    // プルリフレッシュによる手動同期を駆動するトリガー。
+    // replay=0 にして、再購読時に過去のリフレッシュ信号が再生され二重fetchになるのを防ぐ。
+    // extraBufferCapacity=1 で購読中の tryEmit を確実にバッファする。
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
 
     // トークン変更を起点にネットワーク同期し、その後DBを継続観測する完全リアクティブな一覧
     val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
@@ -68,19 +71,23 @@ class TodoListViewModel @Inject constructor(
                             _isRefreshing.update { true }
                             try {
                                 fetchTodoListUseCase.execute()
+                            } catch (e: CancellationException) {
+                                throw e
                             } catch (e: Exception) {
                                 Timber.e(e)
                                 _result.update { Result.failure(e) }
+                            } finally {
+                                _isRefreshing.update { false }
                             }
-                            _isRefreshing.update { false }
                         }
                         emitAll(getTodoListUseCase.execute())
                     }
+                        // 1サイクルの失敗で共有ストリームを終わらせない（次のリフレッシュで復帰可能にする）
+                        .catch { throwable ->
+                            Timber.e(throwable)
+                            _result.update { Result.failure(throwable) }
+                        }
                 }
-        }
-        .catch { throwable ->
-            Timber.e(throwable)
-            _result.update { Result.failure(throwable) }
         }
         .stateIn(
             scope = viewModelScope,

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -11,17 +11,25 @@ import jp.kztproject.rewardedtodo.application.reward.UpdateTodoUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.EditingTodo
 import jp.kztproject.rewardedtodo.domain.todo.Todo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import javax.inject.Inject
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class TodoListViewModel @Inject constructor(
     private val getTodoListUseCase: GetTodoListUseCase,
@@ -32,7 +40,40 @@ class TodoListViewModel @Inject constructor(
     private val getApiTokenUseCase: GetApiTokenUseCase,
 ) : ViewModel() {
 
-    val todoList: StateFlow<List<Todo>> = getTodoListUseCase.execute()
+    private val _result = MutableStateFlow<Result<Unit>?>(null)
+    val result: StateFlow<Result<Unit>?> = _result.asStateFlow()
+
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing = _isRefreshing.asStateFlow()
+
+    val hasAuthToken: StateFlow<Boolean> = getApiTokenUseCase.executeAsFlow()
+        .map { it != null }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false,
+        )
+
+    // 購読開始時の初回ロードとプルリフレッシュを駆動するトリガー
+    private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1)
+
+    val todoList: StateFlow<List<Todo>> = refreshTrigger
+        .onStart { emit(Unit) }
+        .flatMapLatest {
+            flow {
+                _isRefreshing.update { true }
+                try {
+                    if (getApiTokenUseCase.execute() != null) {
+                        fetchTodoListUseCase.execute()
+                    }
+                } catch (e: Exception) {
+                    Timber.e(e)
+                    _result.update { Result.failure(e) }
+                }
+                _isRefreshing.update { false }
+                emitAll(getTodoListUseCase.execute())
+            }
+        }
         .catch { throwable ->
             Timber.e(throwable)
             _result.update { Result.failure(throwable) }
@@ -43,45 +84,8 @@ class TodoListViewModel @Inject constructor(
             initialValue = emptyList(),
         )
 
-    private val _result = MutableStateFlow<Result<Unit>?>(null)
-    val result: StateFlow<Result<Unit>?> = _result.asStateFlow()
-
-    private val _isRefreshing = MutableStateFlow(false)
-    val isRefreshing = _isRefreshing.asStateFlow()
-
-    private val _hasAuthToken = MutableStateFlow(false)
-    val hasAuthToken = _hasAuthToken.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            checkAuthToken()
-
-            try {
-                if (_hasAuthToken.value) {
-                    fetchTodoListUseCase.execute()
-                }
-            } catch (e: Exception) {
-                Timber.e(e)
-                _result.update { Result.failure(e) }
-            }
-        }
-    }
-
     fun refreshTodoList() {
-        viewModelScope.launch {
-            _isRefreshing.update { true }
-            checkAuthToken()
-
-            try {
-                if (_hasAuthToken.value) {
-                    fetchTodoListUseCase.execute()
-                }
-            } catch (e: Exception) {
-                Timber.e(e)
-                _result.update { Result.failure(e) }
-            }
-            _isRefreshing.update { false }
-        }
+        refreshTrigger.tryEmit(Unit)
     }
 
     fun updateTodo(todo: EditingTodo) {
@@ -111,10 +115,5 @@ class TodoListViewModel @Inject constructor(
 
     fun clearResult() {
         _result.update { null }
-    }
-
-    private suspend fun checkAuthToken() {
-        val token = getApiTokenUseCase.execute()
-        _hasAuthToken.update { token != null }
     }
 }

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -54,12 +55,15 @@ class TodoListViewModel @Inject constructor(
     // トークン変更を起点にネットワーク同期し、その後DBを継続観測する完全リアクティブな一覧
     val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
         .flatMapLatest { token ->
+            // 初回ロード(onStart)は false、手動プルリフレッシュ(refreshTrigger)は true。
+            // プルリフレッシュ用スピナーは手動時のみ表示し、初回ロードでは出さない。
             refreshTrigger
-                .onStart { emit(Unit) }
-                .flatMapLatest {
+                .map { true }
+                .onStart { emit(false) }
+                .flatMapLatest { isManualRefresh ->
                     flow {
                         if (token != null) {
-                            _isRefreshing.update { true }
+                            if (isManualRefresh) _isRefreshing.update { true }
                             try {
                                 fetchTodoListUseCase.execute()
                             } catch (e: CancellationException) {
@@ -68,7 +72,7 @@ class TodoListViewModel @Inject constructor(
                                 Timber.e(e)
                                 _result.update { Result.failure(e) }
                             } finally {
-                                _isRefreshing.update { false }
+                                if (isManualRefresh) _isRefreshing.update { false }
                             }
                         }
                         emitAll(getTodoListUseCase.execute())

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -54,25 +54,29 @@ class TodoListViewModel @Inject constructor(
             initialValue = false,
         )
 
-    // 購読開始時の初回ロードとプルリフレッシュを駆動するトリガー
+    // プルリフレッシュによる手動同期を駆動するトリガー
     private val refreshTrigger = MutableSharedFlow<Unit>(replay = 1)
 
-    val todoList: StateFlow<List<Todo>> = refreshTrigger
-        .onStart { emit(Unit) }
-        .flatMapLatest {
-            flow {
-                _isRefreshing.update { true }
-                try {
-                    if (getApiTokenUseCase.execute() != null) {
-                        fetchTodoListUseCase.execute()
+    // トークン変更を起点にネットワーク同期し、その後DBを継続観測する完全リアクティブな一覧
+    val todoList: StateFlow<List<Todo>> = getApiTokenUseCase.executeAsFlow()
+        .flatMapLatest { token ->
+            refreshTrigger
+                .onStart { emit(Unit) }
+                .flatMapLatest {
+                    flow {
+                        if (token != null) {
+                            _isRefreshing.update { true }
+                            try {
+                                fetchTodoListUseCase.execute()
+                            } catch (e: Exception) {
+                                Timber.e(e)
+                                _result.update { Result.failure(e) }
+                            }
+                            _isRefreshing.update { false }
+                        }
+                        emitAll(getTodoListUseCase.execute())
                     }
-                } catch (e: Exception) {
-                    Timber.e(e)
-                    _result.update { Result.failure(e) }
                 }
-                _isRefreshing.update { false }
-                emitAll(getTodoListUseCase.execute())
-            }
         }
         .catch { throwable ->
             Timber.e(throwable)

--- a/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
+++ b/feature/todo/src/main/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -46,14 +45,6 @@ class TodoListViewModel @Inject constructor(
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing = _isRefreshing.asStateFlow()
-
-    val hasAuthToken: StateFlow<Boolean> = getApiTokenUseCase.executeAsFlow()
-        .map { it != null }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = false,
-        )
 
     // プルリフレッシュによる手動同期を駆動するトリガー。
     // replay=0 にして、再購読時に過去のリフレッシュ信号が再生され二重fetchになるのを防ぐ。

--- a/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
+++ b/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
@@ -1,8 +1,8 @@
 package jp.kztproject.rewardedtodo.presentation.todo
 
 import io.kotest.core.spec.style.ShouldSpec
-import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import jp.kztproject.rewardedtodo.application.reward.CompleteTodoUseCase
 import jp.kztproject.rewardedtodo.application.reward.DeleteTodoUseCase
@@ -13,6 +13,7 @@ import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -44,7 +45,7 @@ class TodoListViewModelTest :
                     val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
                     val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
                     val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
-                    coEvery { getApiTokenUseCase.execute() } returns dummyToken
+                    every { getApiTokenUseCase.executeAsFlow() } returns flowOf(dummyToken)
 
                     val viewModel = TodoListViewModel(
                         getTodoListUseCase,
@@ -73,7 +74,7 @@ class TodoListViewModelTest :
                     val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
                     val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
                     val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
-                    coEvery { getApiTokenUseCase.execute() } returns dummyToken
+                    every { getApiTokenUseCase.executeAsFlow() } returns flowOf(dummyToken)
 
                     val viewModel = TodoListViewModel(
                         getTodoListUseCase,

--- a/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
+++ b/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
@@ -13,6 +13,7 @@ import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -33,35 +34,8 @@ class TodoListViewModelTest :
             Dispatchers.resetMain()
         }
 
-        context("When viewModel is initialized") {
-            should("get todo list") {
-                runTest(testDispatcher) {
-                    val getTodoListUseCase = mockk<GetTodoListUseCase>(relaxed = true)
-                    val fetchTodoListUseCase = mockk<FetchTodoListUseCase>(relaxed = true)
-                    val updateTodoListUseCase = mockk<UpdateTodoUseCase>(relaxed = true)
-                    val deleteTodoUseCase = mockk<DeleteTodoUseCase>(relaxed = true)
-                    val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
-                    val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
-                    val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
-                    coEvery { getApiTokenUseCase.execute() } returns dummyToken
-
-                    TodoListViewModel(
-                        getTodoListUseCase,
-                        fetchTodoListUseCase,
-                        updateTodoListUseCase,
-                        deleteTodoUseCase,
-                        completeTodoUseCase,
-                        getApiTokenUseCase,
-                    )
-
-                    advanceUntilIdle()
-                    coVerify(exactly = 1) { fetchTodoListUseCase.execute() }
-                }
-            }
-        }
-
-        context("When refreshTodoList is called") {
-            should("call fetchTodoListUseCase") {
+        context("When todoList is subscribed") {
+            should("fetch todo list once") {
                 runTest(testDispatcher) {
                     val getTodoListUseCase = mockk<GetTodoListUseCase>(relaxed = true)
                     val fetchTodoListUseCase = mockk<FetchTodoListUseCase>(relaxed = true)
@@ -81,11 +55,42 @@ class TodoListViewModelTest :
                         getApiTokenUseCase,
                     )
 
+                    val job = backgroundScope.launch { viewModel.todoList.collect {} }
+                    advanceUntilIdle()
+                    coVerify(exactly = 1) { fetchTodoListUseCase.execute() }
+                    job.cancel()
+                }
+            }
+        }
+
+        context("When refreshTodoList is called") {
+            should("call fetchTodoListUseCase again") {
+                runTest(testDispatcher) {
+                    val getTodoListUseCase = mockk<GetTodoListUseCase>(relaxed = true)
+                    val fetchTodoListUseCase = mockk<FetchTodoListUseCase>(relaxed = true)
+                    val updateTodoListUseCase = mockk<UpdateTodoUseCase>(relaxed = true)
+                    val deleteTodoUseCase = mockk<DeleteTodoUseCase>(relaxed = true)
+                    val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
+                    val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
+                    val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
+                    coEvery { getApiTokenUseCase.execute() } returns dummyToken
+
+                    val viewModel = TodoListViewModel(
+                        getTodoListUseCase,
+                        fetchTodoListUseCase,
+                        updateTodoListUseCase,
+                        deleteTodoUseCase,
+                        completeTodoUseCase,
+                        getApiTokenUseCase,
+                    )
+
+                    val job = backgroundScope.launch { viewModel.todoList.collect {} }
                     advanceUntilIdle()
                     viewModel.refreshTodoList()
                     advanceUntilIdle()
 
                     coVerify(exactly = 2) { fetchTodoListUseCase.execute() }
+                    job.cancel()
                 }
             }
         }

--- a/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
+++ b/feature/todo/src/test/java/jp/kztproject/rewardedtodo/presentation/todo/TodoListViewModelTest.kt
@@ -1,6 +1,8 @@
 package jp.kztproject.rewardedtodo.presentation.todo
 
+import com.google.common.truth.Truth.assertThat
 import io.kotest.core.spec.style.ShouldSpec
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -11,6 +13,7 @@ import jp.kztproject.rewardedtodo.application.reward.GetTodoListUseCase
 import jp.kztproject.rewardedtodo.application.reward.UpdateTodoUseCase
 import jp.kztproject.rewardedtodo.application.todo.GetApiTokenUseCase
 import jp.kztproject.rewardedtodo.domain.todo.ApiToken
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -91,6 +94,86 @@ class TodoListViewModelTest :
                     advanceUntilIdle()
 
                     coVerify(exactly = 2) { fetchTodoListUseCase.execute() }
+                    job.cancel()
+                }
+            }
+        }
+
+        context("When the initial load is in flight") {
+            should("not show the pull-to-refresh indicator") {
+                runTest(testDispatcher) {
+                    val getTodoListUseCase = mockk<GetTodoListUseCase>(relaxed = true)
+                    val fetchTodoListUseCase = mockk<FetchTodoListUseCase>(relaxed = true)
+                    val updateTodoListUseCase = mockk<UpdateTodoUseCase>(relaxed = true)
+                    val deleteTodoUseCase = mockk<DeleteTodoUseCase>(relaxed = true)
+                    val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
+                    val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
+                    val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
+                    every { getApiTokenUseCase.executeAsFlow() } returns flowOf(dummyToken)
+                    val fetchGate = CompletableDeferred<Unit>()
+                    coEvery { fetchTodoListUseCase.execute() } coAnswers { fetchGate.await() }
+
+                    val viewModel = TodoListViewModel(
+                        getTodoListUseCase,
+                        fetchTodoListUseCase,
+                        updateTodoListUseCase,
+                        deleteTodoUseCase,
+                        completeTodoUseCase,
+                        getApiTokenUseCase,
+                    )
+
+                    val job = backgroundScope.launch { viewModel.todoList.collect {} }
+                    advanceUntilIdle()
+                    // 初回ロードの同期中でもスピナーは出さない
+                    assertThat(viewModel.isRefreshing.value).isFalse()
+
+                    fetchGate.complete(Unit)
+                    advanceUntilIdle()
+                    job.cancel()
+                }
+            }
+        }
+
+        context("When a manual refresh is in flight") {
+            should("show the pull-to-refresh indicator") {
+                runTest(testDispatcher) {
+                    val getTodoListUseCase = mockk<GetTodoListUseCase>(relaxed = true)
+                    val fetchTodoListUseCase = mockk<FetchTodoListUseCase>(relaxed = true)
+                    val updateTodoListUseCase = mockk<UpdateTodoUseCase>(relaxed = true)
+                    val deleteTodoUseCase = mockk<DeleteTodoUseCase>(relaxed = true)
+                    val completeTodoUseCase = mockk<CompleteTodoUseCase>(relaxed = true)
+                    val getApiTokenUseCase = mockk<GetApiTokenUseCase>(relaxed = true)
+                    val dummyToken = ApiToken.create("1234567890abcdef1234567890abcdef12345678")
+                    every { getApiTokenUseCase.executeAsFlow() } returns flowOf(dummyToken)
+                    val refreshGate = CompletableDeferred<Unit>()
+                    var fetchCount = 0
+                    coEvery { fetchTodoListUseCase.execute() } coAnswers {
+                        fetchCount++
+                        // 初回は即完了、手動リフレッシュ(2回目)は保留してスピナー表示を観測する
+                        if (fetchCount >= 2) refreshGate.await()
+                    }
+
+                    val viewModel = TodoListViewModel(
+                        getTodoListUseCase,
+                        fetchTodoListUseCase,
+                        updateTodoListUseCase,
+                        deleteTodoUseCase,
+                        completeTodoUseCase,
+                        getApiTokenUseCase,
+                    )
+
+                    val job = backgroundScope.launch { viewModel.todoList.collect {} }
+                    advanceUntilIdle()
+                    assertThat(viewModel.isRefreshing.value).isFalse()
+
+                    viewModel.refreshTodoList()
+                    advanceUntilIdle()
+                    // 手動リフレッシュの同期中はスピナーを表示
+                    assertThat(viewModel.isRefreshing.value).isTrue()
+
+                    refreshGate.complete(Unit)
+                    advanceUntilIdle()
+                    assertThat(viewModel.isRefreshing.value).isFalse()
                     job.cancel()
                 }
             }


### PR DESCRIPTION
## 概要

`TodoListViewModel` / `RewardListViewModel` / `SettingViewModel` の `init {}` ブロック内で行っていた副作用的なデータロードを廃止し、ユースケースをFlowで公開して `stateIn(SharingStarted.WhileSubscribed(5000))` でホットな `StateFlow` に合成する設計へ統一しました。これにより、UI購読開始時にロードが走り、再表示時の鮮度は `WhileSubscribed` の再購読で担保されます。

closes #765

## 仕様書

`docs/specs/2026-06-27-viewmodel-flow-based-load.md`

## 主な変更

- **Domain/Application/Data (todo)**: `IApiTokenRepository.getTokenAsFlow()` / `GetApiTokenUseCase.executeAsFlow()` を追加し、`ApiTokenRepository` で DataStore の `data` Flow をmapして実装（`.first()` を使わずリアクティブに）
- **TodoListViewModel**: `init{}` を廃止。`hasAuthToken` をトークンFlowから導出。ネットワーク同期(`fetchTodoListUseCase`)を `MutableSharedFlow` トリガー＋`onStart` で購読駆動の副作用にし、`refreshTodoList()` はトリガーへemit
- **RewardListViewModel**: `init{ loadPoint() }` と抽選後の手動 `loadPoint()` 呼び出しを廃止。`rewardPoint` をチケットDataStoreのFlowから `stateIn(WhileSubscribed)` で合成（自動更新）
- **SettingViewModel**: `init{}` を廃止。`hasAccessToken` / `tokenUiState` をトークンFlowと編集用 `MutableStateFlow` の `combine` で合成。保存/削除後の手動再ロードも撤廃
- **Cleanup**: 常に `false` で未配線だった `todoistAuthFinished` 導線（`SettingScreen` / `SettingNavigation` / `HomeActivity`）を削除

## 受け入れ条件

- [x] 3つのViewModelの `init {}` ブロックが削除されている
- [x] `TodoListViewModel`/`SettingViewModel` がトークンを `executeAsFlow()` から購読
- [x] `RewardListViewModel.rewardPoint` がFlowから合成され、抽選後に手動ロードなしでポイント更新
- [x] 起動時にTodo一覧・報酬一覧・ポイント・トークン接続状態が従来通り表示
- [x] プルリフレッシュでネットワーク同期が走る
- [x] トークン保存/削除後に接続状態UIが更新
- [x] 全モジュールのユニットテストがパス
- [x] Roborazziに意図しない差分が出ない

## 動作確認

| 種別 | 結果 |
|------|------|
| ユニットテスト（全モジュール `testDebugUnitTest`） | ✅ BUILD SUCCESSFUL |
| Roborazzi（`compareRoborazziDebug`） | ✅ 差分なし |
| spotless / lint | ✅ |
| Maestro E2E（実機） | ✅ 3/3 PASS（`add-todo-flow` / `add-reward-flow` / `single-lottery-flow`） |

`single-lottery-flow` でタブ往復時の再表示ロードと、抽選後のポイント更新（`1 tickets`→`0 tickets`）を実機検証し、手動 `loadPoint()` 削除後もDataStore Flowが自動反映することを確認しました。

## 未決事項

- `GetApiTokenInteractor.executeAsFlow` の専用ユニットテストは未追加（`application:todo` にテスト依存が未設定。実装は単純委譲でViewModelテストが間接カバー）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Todo, reward, and settings screens now refresh reactively as the API token becomes available or is cleared.
  * Reward points and todo list fetching are driven by refresh triggers for more responsive updates.
* **Bug Fixes**
  * Improved consistency of connection/token-related UI state after saving or deleting a token.
  * Fixed reward point refresh behavior after lottery actions.
* **Documentation**
  * Added a new specification describing the migration to Flow-driven, hot UI state.
* **Tests**
  * Updated ViewModel tests to validate behavior via reactive state collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->