### PR TITLE
Claude Codeのmax-turnsを40に引き上げ

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,4 +35,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "@claude"
           claude_args: |
-            --max-turns 15
+            --max-turns 40


### PR DESCRIPTION
## 概要

`@claude` コメントで起動する Claude Code GitHub Action が、ターン数上限（15）に達して `Reached maximum number of turns (15)` で打ち切られるケースがあったため、上限を **15 → 40** に引き上げます。

## 変更内容

`.github/workflows/claude.yml` の `claude_args` の `--max-turns` を `15` から `40` に変更。

## 背景

- エラー: `Error: Execution failed: Reached maximum number of turns (15)`
- 原因: 依頼タスクが15ターン以内に完了しなかったため、Action側の上限で停止していた（ビルド/テストの不具合ではない）
- 対応: より複雑なタスクにも対応できるよう上限を拡張する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the allowed number of Claude conversation turns in the GitHub Actions workflow, enabling longer automated interactions before stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->