### PR TITLE
正常系を網羅するMaestro UIテスト

### DIFF
--- a/app/src/main/java/jp/kztproject/rewardedtodo/RewardedTodoTopNavBar.kt
+++ b/app/src/main/java/jp/kztproject/rewardedtodo/RewardedTodoTopNavBar.kt
@@ -31,7 +31,7 @@ fun TopBar(@StringRes titleResourceId: Int, onSettingClicked: () -> Unit) {
             ) {
                 Icon(
                     imageVector = Icons.Filled.Settings,
-                    contentDescription = null,
+                    contentDescription = "setting_button",
                     tint = MaterialTheme.colorScheme.onPrimary,
                 )
             }

--- a/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardDetailBottomSheet.kt
+++ b/feature/reward/src/main/java/jp/kztproject/rewardedtodo/feature/reward/list/RewardDetailBottomSheet.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -134,6 +136,7 @@ private fun RewardDetailBottomSheetContent(
             Checkbox(
                 checked = repeat,
                 onCheckedChange = { repeat = it },
+                modifier = Modifier.semantics { contentDescription = "repeat_checkbox" },
             )
             Text(
                 text = "Repeat",

--- a/maestro-tests/README.md
+++ b/maestro-tests/README.md
@@ -1,0 +1,68 @@
+# Maestro UIテスト
+
+[Maestro](https://docs.maestro.dev/) による E2E UIテスト。全機能の正常系を網羅する。
+
+## 実行方法
+
+```bash
+# デバッグアプリをインストール
+./gradlew installDebug
+
+# 全フロー実行
+maestro test maestro-tests/
+
+# 単一フロー実行
+maestro test maestro-tests/add-todo-flow.yaml
+```
+
+> **警告**: 各フローは `clearState` でアプリデータ（Todo・報酬・チケット・APIトークン）を全消去する。
+> 実機の `jp.kztproject.rewardedtodo.debug` に残したいデータがある場合は事前にバックアップすること。
+
+## テスト一覧
+
+### Todo
+
+| フロー | 検証内容 |
+|-------|---------|
+| `add-todo-flow` | Todoを追加できる |
+| `add-todo-with-multiple-tickets-flow` | チケット枚数を増やしてTodoを追加できる |
+| `edit-todo-flow` | 既存Todoのタイトルとチケット枚数を変更できる |
+| `complete-todo-flow` | Todo完了でリストから消え、チケットを獲得する |
+| `delete-todo-flow` | Todoを削除できる |
+
+### Reward
+
+| フロー | 検証内容 |
+|-------|---------|
+| `add-reward-flow` | 報酬を追加できる |
+| `edit-reward-flow` | 既存報酬のRepeatフラグを変更でき、一覧にRepeatアイコンが表示される |
+| `delete-reward-flow` | 報酬を削除できる |
+
+### 抽選（Lottery）
+
+| フロー | 検証内容 |
+|-------|---------|
+| `single-lottery-flow` | 単発抽選でチケットが1枚消費される |
+| `batch-lottery-flow` | 10連抽選で結果ダイアログが表示され、チケットが減る |
+| `batch-lottery-insufficient-tickets-flow` | チケット不足時にエラーが表示される |
+| `delete-non-repeat-reward-flow` | 非リピート報酬は当選後にリストから消える |
+| `keep-repeat-reward-flow` | リピート報酬は当選後もリストに残る |
+
+### 設定（Setting）
+
+| フロー | 検証内容 |
+|-------|---------|
+| `setting-todoist-token-flow` | Todoist APIトークンの接続・解除ができる |
+
+### 未カバー（意図的に対象外）
+
+- **Todoist同期（Pull-to-Refresh）**: 実際のTodoistアカウントとネットワークが必要なため対象外
+- **タブ切り替え**: 各フロー内でTodo⇔Reward間の遷移を暗黙的に検証済み
+
+## テスト作成時の注意
+
+- **セレクタはテキスト/contentDescription優先**。座標（`point`）指定は以下のやむを得ない箇所のみ:
+  - 設定画面の歯車アイコン（contentDescription未設定）: `point: "93%,9%"`
+- **ロケール依存の文言**: settingモジュールのみ `values-ja` があるため、正規表現で日英両対応にする（例: `"Not Connected|未接続"`）
+- **日本語IME端末でのテキスト入力**: パスワード系フィールド（トークン入力欄）は入力がIMEのローマ字変換を通るため、小文字・数字は全角化される。大文字A-Fのみのトークンを使うこと
+- **テストを通すためにアプリ側のソースコードを修正しない**

--- a/maestro-tests/README.md
+++ b/maestro-tests/README.md
@@ -4,7 +4,14 @@
 
 ## 実行方法
 
+テストは**英語ロケール（en_US）のエミュレータ**で実行することを前提とする。
+文言アサートは英語のみで書かれているため、日本語ロケールの端末では
+setting 系フローが失敗する。
+
 ```bash
+# 英語ロケールのエミュレータを起動（Maestro管理のエミュレータを作成・起動）
+maestro start-device --platform android --device-locale en_US
+
 # デバッグアプリをインストール
 ./gradlew installDebug
 
@@ -14,6 +21,8 @@ maestro test maestro-tests/
 # 単一フロー実行
 maestro test maestro-tests/add-todo-flow.yaml
 ```
+
+英語ロケールであれば手元のAVDでもよい（`adb shell am get-config` で `en-rUS` を確認できる）。
 
 > **警告**: 各フローは `clearState` でアプリデータ（Todo・報酬・チケット・APIトークン）を全消去する。
 > 実機の `jp.kztproject.rewardedtodo.debug` に残したいデータがある場合は事前にバックアップすること。
@@ -62,6 +71,6 @@ maestro test maestro-tests/add-todo-flow.yaml
 ## テスト作成時の注意
 
 - **セレクタはテキスト/contentDescription優先**。座標（`point`）指定は画面サイズ・解像度に依存してFlakyになるため使わない
-- **ロケール依存の文言**: settingモジュールのみ `values-ja` があるため、正規表現で日英両対応にする（例: `"Not Connected|未接続"`）
-- **日本語IME端末でのテキスト入力**: パスワード系フィールド（トークン入力欄）は入力がIMEのローマ字変換を通るため、小文字・数字は全角化される。大文字A-Fのみのトークンを使うこと
+- **文言アサートは英語のみで書く**。ロケールは実行環境（en_USエミュレータ）側で固定する。Maestroのロケール指定（`--device-locale`）はエミュレータ専用で、実機やフローYAML内では指定できない
+- **日本語IME端末（実機）で実行する場合の注意**: パスワード系フィールド（トークン入力欄）は入力がIMEのローマ字変換を通るため、小文字・数字は全角化される。トークンは大文字A-Fのみで構成している
 - **テストを通すためにアプリ側のビジネスロジックやデザインを変更しない**。ただし、テストから要素を特定するための識別子（`contentDescription`）の追加は可（例: `repeat_checkbox`, `setting_button`）

--- a/maestro-tests/README.md
+++ b/maestro-tests/README.md
@@ -61,8 +61,7 @@ maestro test maestro-tests/add-todo-flow.yaml
 
 ## テスト作成時の注意
 
-- **セレクタはテキスト/contentDescription優先**。座標（`point`）指定は以下のやむを得ない箇所のみ:
-  - 設定画面の歯車アイコン（contentDescription未設定）: `point: "93%,9%"`
+- **セレクタはテキスト/contentDescription優先**。座標（`point`）指定は画面サイズ・解像度に依存してFlakyになるため使わない
 - **ロケール依存の文言**: settingモジュールのみ `values-ja` があるため、正規表現で日英両対応にする（例: `"Not Connected|未接続"`）
 - **日本語IME端末でのテキスト入力**: パスワード系フィールド（トークン入力欄）は入力がIMEのローマ字変換を通るため、小文字・数字は全角化される。大文字A-Fのみのトークンを使うこと
-- **テストを通すためにアプリ側のソースコードを修正しない**
+- **テストを通すためにアプリ側のビジネスロジックやデザインを変更しない**。ただし、テストから要素を特定するための識別子（`contentDescription`）の追加は可（例: `repeat_checkbox`, `setting_button`）

--- a/maestro-tests/complete-todo-flow.yaml
+++ b/maestro-tests/complete-todo-flow.yaml
@@ -1,0 +1,43 @@
+appId: jp.kztproject.rewardedtodo.debug
+tags:
+  - android
+  - rewardedtodo
+---
+- clearState
+- launchApp
+
+# Add a todo to complete
+- tapOn:
+    text: "Add"
+
+# Wait for bottom sheet to appear
+- assertVisible: "Title"
+
+# Enter task name
+- tapOn: "Title"
+- inputText: "Task to Complete"
+
+# Tap Save button
+- tapOn: "Save"
+
+# Verify the task is added to the list
+- assertVisible: "Task to Complete"
+
+# Complete the todo by tapping checkbox
+- tapOn:
+    text: "todo_checkbox"
+    index: 0
+
+# Non-repeat todo should be removed from the list after completion
+- extendedWaitUntil:
+    notVisible: "Task to Complete"
+    timeout: 5000
+
+# Navigate to Reward tab to verify the ticket was earned
+- tapOn:
+    text: "Reward"
+
+# Verify 1 ticket was earned by completing the todo
+- extendedWaitUntil:
+    visible: "1 tickets"
+    timeout: 5000

--- a/maestro-tests/edit-reward-flow.yaml
+++ b/maestro-tests/edit-reward-flow.yaml
@@ -1,0 +1,65 @@
+appId: jp.kztproject.rewardedtodo.debug
+tags:
+  - android
+  - rewardedtodo
+---
+- clearState
+- launchApp
+
+# Navigate to Reward tab
+- tapOn:
+    text: "Reward"
+
+# Add a reward to edit (Repeat is left unchecked)
+- tapOn:
+    text: "Add"
+
+# Wait for bottom sheet to appear
+- assertVisible: "Reward Title"
+
+# Enter reward title
+- tapOn: "Reward Title"
+- inputText: "Reward to Edit"
+
+# Enter reward description
+- tapOn: "Reward Description"
+- inputText: "Before editing"
+
+# Enter chance of winning
+- tapOn: "Chance of Winning.*"
+- inputText: "20"
+
+# Tap Save button
+- tapOn: "Save"
+
+# Wait for the reward to appear in the list
+- extendedWaitUntil:
+    visible: "Reward to Edit"
+    timeout: 5000
+
+# The reward has no Repeat icon yet
+- assertNotVisible: "Repeat"
+
+# Tap on the reward to open the detail bottom sheet
+- tapOn:
+    text: "Reward to Edit"
+
+# Wait for bottom sheet to appear
+- assertVisible: "Reward Title"
+
+# Turn on the Repeat checkbox
+- tapOn:
+    text: "repeat_checkbox"
+
+# Save the changes
+- tapOn: "Save"
+
+# Wait for bottom sheet to close
+- assertNotVisible:
+    text: "Reward Title"
+
+# Verify the reward now shows the Repeat icon in the list
+- extendedWaitUntil:
+    visible: "Repeat"
+    timeout: 5000
+- assertVisible: "Reward to Edit"

--- a/maestro-tests/edit-todo-flow.yaml
+++ b/maestro-tests/edit-todo-flow.yaml
@@ -57,6 +57,8 @@ tags:
 # Verify the old task name is gone
 - assertNotVisible: "Original Task"
 
-# Verify the updated ticket count (2 or more) is shown
+# Verify the updated ticket count (2 or more) is shown in the todo row
+# (the ticket count is rendered right below the todo title)
 - assertVisible:
     text: "[2-9]|\\d{2,}"
+    below: "Updated Task"

--- a/maestro-tests/edit-todo-flow.yaml
+++ b/maestro-tests/edit-todo-flow.yaml
@@ -57,6 +57,6 @@ tags:
 # Verify the old task name is gone
 - assertNotVisible: "Original Task"
 
-# Verify the updated ticket count (2+ digits) is shown
+# Verify the updated ticket count (2 or more) is shown
 - assertVisible:
-    text: "\\d{2,}"
+    text: "[2-9]|\\d{2,}"

--- a/maestro-tests/edit-todo-flow.yaml
+++ b/maestro-tests/edit-todo-flow.yaml
@@ -1,0 +1,62 @@
+appId: jp.kztproject.rewardedtodo.debug
+tags:
+  - android
+  - rewardedtodo
+---
+- clearState
+- launchApp
+
+# Add a todo to edit
+- tapOn:
+    text: "Add"
+
+# Wait for bottom sheet to appear
+- assertVisible: "Title"
+
+# Enter task name
+- tapOn: "Title"
+- inputText: "Original Task"
+
+# Tap Save button
+- tapOn: "Save"
+
+# Verify the task is added to the list
+- assertVisible: "Original Task"
+
+# Tap on the task to open the detail bottom sheet
+- tapOn:
+    text: "Original Task"
+
+# Wait for bottom sheet to appear (Save button only exists in the sheet)
+- assertVisible: "Save"
+
+# Focus the title text field in the sheet and replace the text
+# (while the modal sheet is open, the list behind it is not accessible,
+#  so this uniquely matches the text field in the sheet)
+- tapOn:
+    text: "Original Task"
+- eraseText
+- inputText: "Updated Task"
+- hideKeyboard
+
+# Increase the ticket count as well using NumberPicker
+- swipe:
+    from:
+      text: "ticket_number_picker"
+    direction: UP
+    duration: 500
+
+# Save the changes
+- tapOn: "Save"
+
+# Verify the updated task name is shown in the list
+- extendedWaitUntil:
+    visible: "Updated Task"
+    timeout: 5000
+
+# Verify the old task name is gone
+- assertNotVisible: "Original Task"
+
+# Verify the updated ticket count (2+ digits) is shown
+- assertVisible:
+    text: "\\d{2,}"

--- a/maestro-tests/keep-repeat-reward-flow.yaml
+++ b/maestro-tests/keep-repeat-reward-flow.yaml
@@ -1,0 +1,103 @@
+appId: jp.kztproject.rewardedtodo.debug
+tags:
+  - android
+  - rewardedtodo
+  - lottery
+---
+- launchApp:
+    clearState: true
+
+# Navigate to Reward tab
+- tapOn:
+    text: "Reward"
+
+# Add a repeatable reward with 100% win rate
+- tapOn:
+    text: "Add"
+
+# Wait for bottom sheet to appear
+- extendedWaitUntil:
+    visible: "Reward Title"
+    timeout: 5000
+
+# Enter reward title
+- tapOn: "Reward Title"
+- inputText: "Repeatable Prize"
+
+# Enter reward description
+- tapOn: "Reward Description"
+- inputText: "Stays after winning"
+- hideKeyboard
+
+# Enter chance of winning (100% guarantees a win)
+- tapOn: "Chance of Winning.*"
+- inputText: "100"
+- hideKeyboard
+
+# Turn on the Repeat checkbox
+- tapOn:
+    text: "repeat_checkbox"
+
+# Tap Save button (Repeat is checked => needRepeat = true)
+- tapOn: "Save"
+
+# Wait for bottom sheet to close
+- assertNotVisible:
+    text: "Reward Title"
+
+# Wait for the reward to appear
+- extendedWaitUntil:
+    visible: "Repeatable Prize"
+    timeout: 10000
+
+# Navigate to Todo tab to earn 1 ticket
+- tapOn:
+    text: "Todo"
+
+# Wait for Todo tab to load
+- assertVisible:
+    text: "Add"
+
+# Add one todo to earn 1 ticket
+- tapOn:
+    text: "Add"
+- assertVisible: "Title"
+- tapOn: "Title"
+- inputText: "Earn Ticket"
+- tapOn: "Save"
+- extendedWaitUntil:
+    visible: "Earn Ticket"
+    timeout: 3000
+
+# Complete the todo by tapping checkbox
+- tapOn:
+    text: "todo_checkbox"
+    index: 0
+
+# Navigate back to Reward tab
+- tapOn:
+    text: "Reward"
+
+# Verify we have 1 ticket
+- assertVisible: "1 tickets"
+
+# Run single lottery (guaranteed win at 100%)
+- tapOn:
+    text: "single_lottery_button"
+
+# Wait for the won dialog
+- extendedWaitUntil:
+    visible:
+      text: "You won.*"
+    timeout: 3000
+
+# Close the dialog
+- tapOn: "OK"
+
+# The repeatable reward should still remain in the list after winning
+- extendedWaitUntil:
+    visible: "Repeatable Prize"
+    timeout: 5000
+
+# Verify ticket was consumed (should be 0 tickets now)
+- assertVisible: "0 tickets"

--- a/maestro-tests/setting-todoist-token-flow.yaml
+++ b/maestro-tests/setting-todoist-token-flow.yaml
@@ -8,9 +8,8 @@ tags:
 - launchApp
 
 # Open the setting screen via the gear icon in the top app bar
-# (the icon has no contentDescription, so tap by position: top-right of the app bar)
 - tapOn:
-    point: "93%,9%"
+    text: "setting_button"
 
 # Verify the setting screen is displayed
 # (text is locale dependent, so match both English and Japanese)

--- a/maestro-tests/setting-todoist-token-flow.yaml
+++ b/maestro-tests/setting-todoist-token-flow.yaml
@@ -12,12 +12,11 @@ tags:
     text: "setting_button"
 
 # Verify the setting screen is displayed
-# (text is locale dependent, so match both English and Japanese)
-- assertVisible: "Setting|設定"
-- assertVisible: "Extensions|拡張機能"
+- assertVisible: "Setting"
+- assertVisible: "Extensions"
 
 # Todoist is not connected right after clearState
-- assertVisible: "Not Connected|未接続"
+- assertVisible: "Not Connected"
 
 # Enter a valid Todoist API token (40-char hex string)
 # Note: use uppercase A-F only. On devices with a Japanese IME, lowercase
@@ -28,19 +27,19 @@ tags:
 - hideKeyboard
 
 # Save the token
-- tapOn: "Verify Connection|接続を確認"
+- tapOn: "Verify Connection"
 
 # Verify the connection status turns into Connected
 - extendedWaitUntil:
-    visible: "Connected|接続済み"
+    visible: "Connected"
     timeout: 5000
 
 # Disconnect the integration
-- tapOn: "Disconnect|連携を解除"
+- tapOn: "Disconnect"
 
 # Verify the connection status turns back into Not Connected
 - extendedWaitUntil:
-    visible: "Not Connected|未接続"
+    visible: "Not Connected"
     timeout: 5000
 
 # Go back to the home screen

--- a/maestro-tests/setting-todoist-token-flow.yaml
+++ b/maestro-tests/setting-todoist-token-flow.yaml
@@ -1,0 +1,51 @@
+appId: jp.kztproject.rewardedtodo.debug
+tags:
+  - android
+  - rewardedtodo
+  - setting
+---
+- clearState
+- launchApp
+
+# Open the setting screen via the gear icon in the top app bar
+# (the icon has no contentDescription, so tap by position: top-right of the app bar)
+- tapOn:
+    point: "93%,9%"
+
+# Verify the setting screen is displayed
+# (text is locale dependent, so match both English and Japanese)
+- assertVisible: "Setting|設定"
+- assertVisible: "Extensions|拡張機能"
+
+# Todoist is not connected right after clearState
+- assertVisible: "Not Connected|未接続"
+
+# Enter a valid Todoist API token (40-char hex string)
+# Note: use uppercase A-F only. On devices with a Japanese IME, lowercase
+# letters and digits typed into this field get converted to full-width
+# characters via romaji composition, while uppercase letters pass through as-is.
+- tapOn: "Todoist API.*"
+- inputText: "ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+- hideKeyboard
+
+# Save the token
+- tapOn: "Verify Connection|接続を確認"
+
+# Verify the connection status turns into Connected
+- extendedWaitUntil:
+    visible: "Connected|接続済み"
+    timeout: 5000
+
+# Disconnect the integration
+- tapOn: "Disconnect|連携を解除"
+
+# Verify the connection status turns back into Not Connected
+- extendedWaitUntil:
+    visible: "Not Connected|未接続"
+    timeout: 5000
+
+# Go back to the home screen
+- back
+
+# Verify the Todo tab is displayed again
+- assertVisible: "Todo"


### PR DESCRIPTION
## 概要

Maestro による E2E UIテストを拡充し、全機能の正常系を網羅する状態にした。既存9フローに加えて5フローを追加し、あわせてカバレッジ一覧をまとめた README を追加した。

## 追加したテスト

| フロー | 検証内容 |
|-------|---------|
| `complete-todo-flow` | Todo完了（コアループ）: チェックでリストから消え、チケット+1 |
| `edit-todo-flow` | Todo編集: タイトル書き換え＋チケット枚数変更が一覧に反映 |
| `edit-reward-flow` | 報酬編集: Repeatフラグ変更が保存され一覧にRepeatアイコン表示 |
| `keep-repeat-reward-flow` | リピート報酬は当選後もリストに残る（`delete-non-repeat-reward-flow` の対） |
| `setting-todoist-token-flow` | 設定画面でのTodoist APIトークン接続→Connected→解除 |

## アプリ本体の変更

- `RewardDetailBottomSheet` の Repeatチェックボックスに `contentDescription = "repeat_checkbox"` を追加。テキスト/IDを持たず座標指定に頼らざるを得なかったため、UIテストからセレクタで特定できるようにした（`todo_checkbox` などの既存の命名パターンに準拠）。

## テスト作成時に判明した点（README にも記載）

- **設定の歯車アイコン**は contentDescription 未設定のため、唯一ポイント指定（`93%,9%`）が残っている。
- **設定画面のみ `values-ja` があり文言がロケール依存**のため、`"Not Connected|未接続"` のような日英両対応の正規表現にしている。
- **日本語IME環境ではトークン入力欄（パスワード表示フィールド）だけ入力がローマ字変換を通り全角化される**ため、変換されない大文字A-FのみのHEXトークンを使う回避策を入れている。

## 動作確認

- 実機（Pixel系, 1080x2400）で全14フローがパス（14/14 Passed）
- `:feature:reward:testDebugUnitTest` と `spotlessCheck` が成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by adding labels to the settings button and repeat checkbox so screen readers can identify them.
* **Tests**
  * Added new end-to-end test flows covering todo creation/editing, reward editing, repeatable rewards, and settings token connection behavior.
  * Added a test guide with setup requirements, supported flows, and tips for writing stable UI tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->