### PR TITLE
Fix screenshot-comment WFの外部入力の扱いを堅牢化

### DIFF
--- a/.github/workflows/screenshot-comparison-comment.yml
+++ b/.github/workflows/screenshot-comparison-comment.yml
@@ -40,7 +40,13 @@ jobs:
         name: Get pull request number
         shell: bash
         run: |
-          echo "pull_request_number=$(cat NR)" >> "$GITHUB_OUTPUT"
+          # PR番号は外部入力のため数値のみ許可する
+          nr="$(cat NR)"
+          if ! [[ "$nr" =~ ^[0-9]+$ ]]; then
+            echo "Invalid PR number in NR artifact: $nr" >&2
+            exit 1
+          fi
+          echo "pull_request_number=$nr" >> "$GITHUB_OUTPUT"
 
       - uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
@@ -48,8 +54,17 @@ jobs:
           name: screenshot-diff-reports
           path: screenshot-diff-reports
       - id: collect-compare-images
+        shell: bash
         run: |
           files=$(find . -type f -name '*_compare.png' | sort)
+          # ファイルパスは安全な文字のみ許可する
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            if ! printf '%s' "$file" | grep -qE '^[A-Za-z0-9_./-]+$'; then
+              echo "Unsafe file path detected in artifact: $file" >&2
+              exit 1
+            fi
+          done <<< "$files"
           delimiter="$(openssl rand -hex 8)"
           {
             echo "screenshot_compare_images<<${delimiter}"
@@ -62,6 +77,10 @@ jobs:
         if: steps.collect-compare-images.outputs.screenshot_compare_images != ''
         env:
           BRANCH_NAME: companion_${{ github.event.workflow_run.head_branch }}
+          # 外部入力は env 経由で渡す（run: への直接展開を避ける）
+          COMPARE_IMAGES: ${{ steps.collect-compare-images.outputs.screenshot_compare_images }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
         run: |
           delimiter="$(openssl rand -hex 8)"
           {
@@ -73,10 +92,10 @@ jobs:
           git branch -D "$BRANCH_NAME" || true
           git checkout --orphan "$BRANCH_NAME"
           git rm -rf .
-          echo "${{ steps.collect-compare-images.outputs.screenshot_compare_images }}" | while read file; do
+          while IFS= read -r file; do
             [ -n "$file" ] && git add "$file"
-            echo "![](https://github.com/${{ github.repository }}/blob/${BRANCH_NAME}/$(echo "${file}" | sed 's|^\./||')?raw=true)" >> "$GITHUB_OUTPUT"
-          done
+            echo "![](https://github.com/${REPOSITORY}/blob/${BRANCH_NAME}/$(echo "${file}" | sed 's|^\./||')?raw=true)" >> "$GITHUB_OUTPUT"
+          done <<< "$COMPARE_IMAGES"
           echo "${delimiter}" >> "$GITHUB_OUTPUT"
           git config --global user.name github-actions[bot]
           git config --global user.email github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
## 概要

`screenshot-comparison-comment.yml`（`workflow_run` トリガー・特権コンテキストで実行）が、前段ワークフローの artifact 由来の値（PR番号・比較画像のファイルパス）を `run:` スクリプトへ `${{ }}` で直接展開していた。GitHub 公式が推奨する外部入力の扱いに反しており、式インジェクションの余地があったため堅牢化する。

## 変更内容

- **PR番号（`NR`）の検証** — artifact の中身を数値のみ許可するよう検証し、不正な場合は fail させる
- **ファイルパスのホワイトリスト検証** — 収集した `*_compare.png` のパスを安全な文字のみ許可
- **`env` 経由での受け渡し** — ファイルパス一覧・リポジトリ名を `env` に移し、`run:` 内での `${{ }}` 直接展開を排除
- 上記ステップに `shell: bash` を明示（`[[ ]]` / here-string 使用のため）

## 補足

- 現状のリポジトリ設定では fork PR のワークフロー実行に承認（first-time contributors）が必要なため、即時の無条件悪用にはならない。ただし承認済みコントリビューターや誤承認の経路が残るため、多層防御として対処する
- YAML 構文と防御ロジック（正常パスは通過・シェルメタ文字/空白を含むパスは拒否）はローカルで検証済み

## 関連

別途、リポジトリのデフォルトワークフロー権限を read 化する設定変更、および各ワークフローへの最小 `permissions:` 明示を推奨（本PRのスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety checks for screenshot comparison comments by rejecting invalid PR numbers and unsafe file paths.
  * Made screenshot image handling more robust when generating comparison results for pull requests.
* **Chores**
  * Tightened workflow handling for external inputs used in screenshot comparison automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->